### PR TITLE
fix: resolve P0 workspace and orchestration stability issues

### DIFF
--- a/desktop/src/custom-agent-store.cjs
+++ b/desktop/src/custom-agent-store.cjs
@@ -178,6 +178,9 @@ class CustomAgentStore {
   async run(kind, prompt, workdir, options = {}) {
     const definition = this.definitions.find(item => item.kind === kind)
     if (!definition) throw customAgentError('CUSTOM_AGENT_NOT_FOUND')
+    if (options.sandbox !== 'workspace-write') {
+      throw customAgentError('CUSTOM_AGENT_READ_ONLY_UNSUPPORTED')
+    }
     const executable = executablePath(definition.executable, this.platform)
     const attachments = normalizeAttachments(options.attachments)
     const attachmentContext = attachments.length

--- a/desktop/src/local-workspace-auto-runner.cjs
+++ b/desktop/src/local-workspace-auto-runner.cjs
@@ -339,214 +339,343 @@ class LocalWorkspaceAutoRunner {
     }
   }
 
+  orchestrationCursor(targetKinds) {
+    return {
+      version: 1,
+      workflow: 'auto',
+      currentKind: '',
+      pendingKinds: [...targetKinds],
+      activeKinds: [...targetKinds],
+      successfulKinds: [],
+      agreementKinds: [],
+      attachmentRecipients: [],
+      totalSuccesses: 0,
+      terminalFailureOccurred: false,
+    }
+  }
+
+  checkpointOrchestration(group, controller, updates = {}) {
+    controller.orchestration = { ...controller.orchestration, ...updates }
+    const persisted = this.checkpointRun?.(group.id, controller)
+    if (this.hasRunLedger() && persisted !== true) {
+      throw new Error('LOCAL_RUN_PERSIST_FAILED')
+    }
+  }
+
+  async automaticContext(group, controller, threadRootId, preparedContext = null) {
+    let rootAttachments = preparedContext?.attachments
+    let rootSkillsByKind = preparedContext?.skillHintsByKind
+    let rootKnowledgeBasesByKind = preparedContext?.knowledgeBaseHintsByKind
+    let rootMediaRequest = preparedContext?.mediaRequest || null
+    if (!rootAttachments || !rootSkillsByKind || !rootKnowledgeBasesByKind) {
+      const rootMessage = this.state().messages.find(message => (
+        message.id === threadRootId && message.groupId === group.id && message.role === 'user'
+      ))
+      rootMediaRequest = mediaGenerationRequest(rootMessage?.content || '')
+      rootAttachments = await this.resolveAttachments(rootMessage?.attachments || [])
+      rootSkillsByKind = new Map()
+      for (const kind of controller.targetKinds) {
+        const scoped = (rootMessage?.skillHints || []).filter(skill => skill.targetKind === kind)
+        if (!scoped.length) {
+          rootSkillsByKind.set(kind, [])
+          continue
+        }
+        try {
+          const validated = await this.validateSkillSelections(kind, scoped)
+          rootSkillsByKind.set(
+            kind,
+            Array.isArray(validated) && validated.every(skill => skill?.targetKind === kind)
+              ? validated
+              : [],
+          )
+        } catch {
+          rootSkillsByKind.set(kind, [])
+        }
+      }
+      let storedKnowledgeBaseHints = []
+      try {
+        const validated = await this.validateKnowledgeBaseSelections(
+          controller.targetKinds,
+          rootMessage?.knowledgeBaseHints || [],
+        )
+        storedKnowledgeBaseHints = (Array.isArray(validated) ? validated : [])
+          .map(normalizeKnowledgeBaseHint)
+          .filter(Boolean)
+      } catch { /* unavailable knowledge bases are omitted when resuming */ }
+      rootKnowledgeBasesByKind = new Map(controller.targetKinds.map(kind => [
+        kind,
+        storedKnowledgeBaseHints.filter(source => source.targetKinds.includes(kind)),
+      ]))
+    }
+    return {
+      rootAttachments,
+      rootSkillsByKind,
+      rootKnowledgeBasesByKind,
+      rootMediaRequest,
+    }
+  }
+
+  async runRounds(group, controller, threadRootId, maxRounds, context, resume = false) {
+    const {
+      rootAttachments,
+      rootSkillsByKind,
+      rootKnowledgeBasesByKind,
+      rootMediaRequest,
+    } = context
+    const mediaOwnerKind = rootMediaRequest ? controller.targetKinds[0] : ''
+    const cursor = resume ? controller.orchestration : null
+    const attachmentRecipients = new Set(cursor?.attachmentRecipients || [])
+    let terminalFailureOccurred = cursor?.terminalFailureOccurred === true
+    let activeKinds = cursor ? [...cursor.activeKinds] : [...controller.targetKinds]
+    let totalSuccesses = cursor?.totalSuccesses || 0
+    let consensusReached = false
+    const reportedFailures = new Set()
+    const firstRound = resume ? Math.max(0, controller.currentRound - 1) : 0
+
+    for (
+      let round = firstRound;
+      (controller.unlimitedRounds || round < maxRounds) && !controller.signal.aborted;
+      round += 1
+    ) {
+      const resumedRound = resume && round === firstRound
+      const successfulKinds = new Set(resumedRound ? cursor.successfulKinds : [])
+      const agreementKinds = new Set(resumedRound ? cursor.agreementKinds : [])
+      const replacementInstructions = new Map()
+      const roundQueue = resumedRound ? [...cursor.pendingKinds] : [...activeKinds]
+      controller.currentRound = round + 1
+      controller.completedKinds = resumedRound
+        ? activeKinds.filter(kind => !roundQueue.includes(kind))
+        : []
+      controller.failedKinds = resumedRound
+        ? controller.completedKinds.filter(kind => !successfulKinds.has(kind))
+        : []
+      if (!resumedRound) {
+        this.checkpointOrchestration(group, controller, {
+          currentKind: '',
+          pendingKinds: [...roundQueue],
+          activeKinds: [...activeKinds],
+          successfulKinds: [],
+          agreementKinds: [],
+          attachmentRecipients: [...attachmentRecipients],
+          totalSuccesses,
+          terminalFailureOccurred,
+        })
+      }
+      this.emitChanged()
+
+      while (roundQueue.length) {
+        const kind = roundQueue.shift()
+        if (!activeKinds.includes(kind)) {
+          this.checkpointOrchestration(group, controller, { pendingKinds: [...roundQueue] })
+          continue
+        }
+        if (controller.signal.aborted) break
+        const executionKind = kind
+        this.setCurrentAgent(controller, executionKind)
+        this.checkpointOrchestration(group, controller, {
+          currentKind: executionKind,
+          pendingKinds: [...roundQueue],
+          activeKinds: [...activeKinds],
+          successfulKinds: [...successfulKinds],
+          agreementKinds: [...agreementKinds],
+          attachmentRecipients: [...attachmentRecipients],
+          totalSuccesses,
+          terminalFailureOccurred,
+        })
+        try {
+          const attachments = attachmentRecipients.has(executionKind)
+            ? []
+            : rootAttachments.map(attachment => attachment.path)
+          const invocation = await this.invokeWithUnauthorizedRecovery({
+            group,
+            kind: executionKind,
+            controller,
+            activeKinds,
+            threadRootId,
+            context: {
+              attachments,
+              attachmentSnapshots: attachments.length ? rootAttachments : [],
+              skillHints: rootSkillsByKind.get(executionKind) || [],
+              knowledgeBaseHints: rootKnowledgeBasesByKind.get(executionKind) || [],
+              runtimeInstruction: replacementInstructions.get(executionKind) || '',
+              mediaRequest: executionKind === mediaOwnerKind && round === 0
+                ? rootMediaRequest
+                : null,
+              contextOptions: { focusUserMessageId: threadRootId },
+            },
+            reportedFailures,
+          })
+          replacementInstructions.delete(executionKind)
+          if (invocation.control?.action === 'replace') {
+            this.recordAgentInterruption(
+              group.id, executionKind, invocation.error, threadRootId, 'stopped', reportedFailures,
+            )
+            if (!controller.failedKinds.includes(executionKind)) {
+              controller.failedKinds.push(executionKind)
+            }
+            if (!controller.completedKinds.includes(executionKind)) {
+              controller.completedKinds.push(executionKind)
+            }
+            successfulKinds.delete(executionKind)
+            agreementKinds.delete(executionKind)
+            const replacementKind = invocation.control.replacementKind
+            activeKinds = activeKinds.filter(activeKind => activeKind !== executionKind)
+            replacementInstructions.set(
+              replacementKind,
+              this.replacementInstruction(executionKind),
+            )
+            if (!roundQueue.includes(replacementKind)) roundQueue.unshift(replacementKind)
+            controller.currentKind = ''
+            controller.progress = []
+            this.checkpointOrchestration(group, controller, {
+              currentKind: '',
+              pendingKinds: [...roundQueue],
+              activeKinds: [...activeKinds],
+              successfulKinds: [...successfulKinds],
+              agreementKinds: [...agreementKinds],
+            })
+            this.emitChanged()
+            continue
+          }
+          if (invocation.control?.action === 'cancel') {
+            this.recordAgentInterruption(
+              group.id, executionKind, invocation.error, threadRootId, 'stopped', reportedFailures,
+            )
+            if (!controller.failedKinds.includes(executionKind)) {
+              controller.failedKinds.push(executionKind)
+            }
+            if (!controller.completedKinds.includes(executionKind)) {
+              controller.completedKinds.push(executionKind)
+            }
+            successfulKinds.delete(executionKind)
+            agreementKinds.delete(executionKind)
+            controller.currentKind = ''
+            controller.progress = []
+            this.checkpointOrchestration(group, controller, {
+              currentKind: '',
+              pendingKinds: [...roundQueue],
+              successfulKinds: [...successfulKinds],
+              agreementKinds: [...agreementKinds],
+            })
+            this.emitChanged()
+            continue
+          }
+          const result = invocation.result
+          if (attachments.length) attachmentRecipients.add(executionKind)
+          successfulKinds.add(executionKind)
+          if (result.consensus) agreementKinds.add(executionKind)
+          else agreementKinds.delete(executionKind)
+        } catch (error) {
+          if (controller.signal.aborted) {
+            const interruptedKind = controller.currentKind || executionKind
+            if (error?.runTrace) {
+              this.recordAgentInterruption(
+                group.id,
+                interruptedKind,
+                error,
+                threadRootId,
+                controller.stopReason === 'shutdown' ? 'interrupted' : 'stopped',
+                reportedFailures,
+              )
+              if (!controller.completedKinds.includes(interruptedKind)) {
+                controller.completedKinds.push(interruptedKind)
+              }
+              controller.currentKind = ''
+              controller.progress = []
+              this.emitChanged()
+            }
+            break
+          }
+          this.recordAgentFailure(
+            group.id, executionKind, error, threadRootId, reportedFailures,
+          )
+          successfulKinds.delete(executionKind)
+          agreementKinds.delete(executionKind)
+          if (!controller.failedKinds.includes(executionKind)) {
+            controller.failedKinds.push(executionKind)
+          }
+          if (['authentication', 'compatibility'].includes(normalizeFailure(error).category)) {
+            terminalFailureOccurred = true
+            activeKinds = activeKinds.filter(activeKind => activeKind !== executionKind)
+          }
+        }
+        if (controller.signal.aborted) break
+        if (!controller.completedKinds.includes(executionKind)) {
+          controller.completedKinds.push(executionKind)
+        }
+        controller.currentKind = ''
+        controller.progress = []
+        this.checkpointOrchestration(group, controller, {
+          currentKind: '',
+          pendingKinds: [...roundQueue],
+          activeKinds: [...activeKinds],
+          successfulKinds: [...successfulKinds],
+          agreementKinds: [...agreementKinds],
+          attachmentRecipients: [...attachmentRecipients],
+          totalSuccesses,
+          terminalFailureOccurred,
+        })
+        this.emitChanged()
+      }
+
+      if (controller.signal.aborted) break
+      const successes = activeKinds.filter(kind => successfulKinds.has(kind)).length
+      const agreements = activeKinds.filter(kind => agreementKinds.has(kind)).length
+      totalSuccesses += successes
+      this.checkpointOrchestration(group, controller, {
+        currentKind: '',
+        pendingKinds: [],
+        activeKinds: [...activeKinds],
+        successfulKinds: [...successfulKinds],
+        agreementKinds: [...agreementKinds],
+        attachmentRecipients: [...attachmentRecipients],
+        totalSuccesses,
+        terminalFailureOccurred,
+      })
+      if (activeKinds.length < 2) break
+      if (successes === activeKinds.length && agreements === activeKinds.length) {
+        consensusReached = true
+        break
+      }
+    }
+
+    let runStatus
+    if (controller.signal.aborted) {
+      runStatus = controller.stopReason === 'shutdown' ? 'interrupted' : 'stopped'
+    } else if (terminalFailureOccurred) runStatus = totalSuccesses > 0 ? 'partial' : 'failed'
+    else if (consensusReached) runStatus = 'completed'
+    else runStatus = totalSuccesses > 0 ? 'round-limit' : 'failed'
+    if (!terminalFailureOccurred && !controller.unlimitedRounds
+        && (runStatus === 'round-limit' || runStatus === 'failed')) {
+      this.addMessage(
+        group.id,
+        'system',
+        `Automatic discussion reached the ${maxRounds}-round safety limit without consensus.`,
+        '',
+        threadRootId,
+        { key: 'system.autoRoundLimit', params: { rounds: maxRounds } },
+      )
+    }
+    return runStatus
+  }
+
   start(
     group, targetKinds, threadRootId, maxRounds, reservation = null, preparedContext = null,
     unlimitedRounds = false,
   ) {
+    reservation.orchestration = this.orchestrationCursor(targetKinds)
     const controller = this.beginRun(
       group.id, 'auto', targetKinds, threadRootId, reservation, maxRounds, unlimitedRounds,
     )
     const promise = (async () => {
       let runStatus = 'failed'
-      let totalSuccesses = 0
       try {
-        let rootAttachments = preparedContext?.attachments
-        let rootSkillsByKind = preparedContext?.skillHintsByKind
-        let rootKnowledgeBasesByKind = preparedContext?.knowledgeBaseHintsByKind
-        let rootMediaRequest = preparedContext?.mediaRequest || null
-        if (!rootAttachments || !rootSkillsByKind || !rootKnowledgeBasesByKind) {
-          const rootMessage = this.state().messages.find(message => (
-            message.id === threadRootId && message.groupId === group.id && message.role === 'user'
-          ))
-          rootMediaRequest = mediaGenerationRequest(rootMessage?.content || '')
-          rootAttachments = await this.resolveAttachments(rootMessage?.attachments || [])
-          rootSkillsByKind = new Map()
-          for (const kind of controller.targetKinds) {
-            const scoped = (rootMessage?.skillHints || []).filter(skill => skill.targetKind === kind)
-            if (!scoped.length) {
-              rootSkillsByKind.set(kind, [])
-              continue
-            }
-            try {
-              const validated = await this.validateSkillSelections(kind, scoped)
-              rootSkillsByKind.set(
-                kind,
-                Array.isArray(validated) && validated.every(skill => skill?.targetKind === kind)
-                  ? validated
-                  : [],
-              )
-            } catch {
-              rootSkillsByKind.set(kind, [])
-            }
-          }
-          let storedKnowledgeBaseHints = []
-          try {
-            const validated = await this.validateKnowledgeBaseSelections(
-              controller.targetKinds,
-              rootMessage?.knowledgeBaseHints || [],
-            )
-            storedKnowledgeBaseHints = (Array.isArray(validated) ? validated : [])
-              .map(normalizeKnowledgeBaseHint)
-              .filter(Boolean)
-          } catch { /* unavailable knowledge bases are omitted when resuming */ }
-          rootKnowledgeBasesByKind = new Map(controller.targetKinds.map(kind => [
-            kind,
-            storedKnowledgeBaseHints.filter(source => source.targetKinds.includes(kind)),
-          ]))
-        }
-        const mediaOwnerKind = rootMediaRequest ? controller.targetKinds[0] : ''
-        const attachmentRecipients = new Set()
-        let consensusReached = false
-        let terminalFailureOccurred = false
-        let activeKinds = [...controller.targetKinds]
-        const reportedFailures = new Set()
-        for (
-          let round = 0;
-          (controller.unlimitedRounds || round < maxRounds) && !controller.signal.aborted;
-          round += 1
-        ) {
-          const successfulKinds = new Set()
-          const agreementKinds = new Set()
-          const replacementInstructions = new Map()
-          const roundQueue = [...activeKinds]
-          controller.currentRound = round + 1
-          controller.completedKinds = []
-          controller.failedKinds = []
-          this.emitChanged()
-          while (roundQueue.length) {
-            const kind = roundQueue.shift()
-            if (!activeKinds.includes(kind)) continue
-            if (controller.signal.aborted) break
-            let executionKind = kind
-            try {
-              const attachments = attachmentRecipients.has(executionKind)
-                ? []
-                : rootAttachments.map(attachment => attachment.path)
-              const invocation = await this.invokeWithUnauthorizedRecovery({
-                group,
-                kind: executionKind,
-                controller,
-                activeKinds,
-                threadRootId,
-                context: {
-                  attachments,
-                  attachmentSnapshots: attachments.length ? rootAttachments : [],
-                  skillHints: rootSkillsByKind.get(executionKind) || [],
-                  knowledgeBaseHints: rootKnowledgeBasesByKind.get(executionKind) || [],
-                  runtimeInstruction: replacementInstructions.get(executionKind) || '',
-                  mediaRequest: executionKind === mediaOwnerKind && round === 0
-                    ? rootMediaRequest
-                    : null,
-                  contextOptions: { focusUserMessageId: threadRootId },
-                },
-                reportedFailures,
-              })
-              replacementInstructions.delete(executionKind)
-              if (invocation.control?.action === 'replace') {
-                this.recordAgentInterruption(
-                  group.id, executionKind, invocation.error, threadRootId, 'stopped', reportedFailures,
-                )
-                if (!controller.failedKinds.includes(executionKind)) {
-                  controller.failedKinds.push(executionKind)
-                }
-                if (!controller.completedKinds.includes(executionKind)) {
-                  controller.completedKinds.push(executionKind)
-                }
-                successfulKinds.delete(executionKind)
-                agreementKinds.delete(executionKind)
-                const replacementKind = invocation.control.replacementKind
-                activeKinds = activeKinds.filter(activeKind => activeKind !== executionKind)
-                replacementInstructions.set(
-                  replacementKind,
-                  this.replacementInstruction(executionKind),
-                )
-                if (!roundQueue.includes(replacementKind)) roundQueue.unshift(replacementKind)
-                controller.currentKind = ''
-                controller.progress = []
-                this.emitChanged()
-                continue
-              }
-              if (invocation.control?.action === 'cancel') {
-                this.recordAgentInterruption(
-                  group.id, executionKind, invocation.error, threadRootId, 'stopped', reportedFailures,
-                )
-                controller.failedKinds.push(executionKind)
-                controller.completedKinds.push(executionKind)
-                controller.currentKind = ''
-                controller.progress = []
-                this.emitChanged()
-                continue
-              }
-              const result = invocation.result
-              if (attachments.length) attachmentRecipients.add(executionKind)
-              successfulKinds.add(executionKind)
-              if (result.consensus) agreementKinds.add(executionKind)
-              else agreementKinds.delete(executionKind)
-            } catch (error) {
-              if (controller.signal.aborted) {
-                const interruptedKind = controller.currentKind || executionKind
-                if (error?.runTrace) {
-                  this.recordAgentInterruption(
-                    group.id,
-                    interruptedKind,
-                    error,
-                    threadRootId,
-                    controller.stopReason === 'shutdown' ? 'interrupted' : 'stopped',
-                    reportedFailures,
-                  )
-                  controller.completedKinds.push(interruptedKind)
-                  controller.currentKind = ''
-                  controller.progress = []
-                  this.emitChanged()
-                }
-                break
-              }
-              this.recordAgentFailure(
-                group.id, executionKind, error, threadRootId, reportedFailures,
-              )
-              successfulKinds.delete(executionKind)
-              agreementKinds.delete(executionKind)
-              if (!controller.failedKinds.includes(executionKind)) {
-                controller.failedKinds.push(executionKind)
-              }
-              if (['authentication', 'compatibility'].includes(normalizeFailure(error).category)) {
-                terminalFailureOccurred = true
-                activeKinds = activeKinds.filter(activeKind => activeKind !== executionKind)
-              }
-            }
-            if (!controller.completedKinds.includes(executionKind)) {
-              controller.completedKinds.push(executionKind)
-            }
-            controller.currentKind = ''
-            controller.progress = []
-            this.emitChanged()
-          }
-          const successes = activeKinds.filter(kind => successfulKinds.has(kind)).length
-          const agreements = activeKinds.filter(kind => agreementKinds.has(kind)).length
-          totalSuccesses += successes
-          if (controller.signal.aborted) break
-          if (activeKinds.length < 2) break
-          if (successes === activeKinds.length && agreements === activeKinds.length) {
-            consensusReached = true
-            break
-          }
-        }
-        if (controller.signal.aborted) {
-          runStatus = controller.stopReason === 'shutdown' ? 'interrupted' : 'stopped'
-        } else if (terminalFailureOccurred) runStatus = totalSuccesses > 0 ? 'partial' : 'failed'
-        else if (consensusReached) runStatus = 'completed'
-        else runStatus = totalSuccesses > 0 ? 'round-limit' : 'failed'
-        if (!terminalFailureOccurred && !controller.unlimitedRounds
-            && (runStatus === 'round-limit' || runStatus === 'failed')) {
-          this.addMessage(
-            group.id,
-            'system',
-            `Automatic discussion reached the ${maxRounds}-round safety limit without consensus.`,
-            '',
-            threadRootId,
-            { key: 'system.autoRoundLimit', params: { rounds: maxRounds } },
-          )
-        }
+        const context = await this.automaticContext(
+          group, controller, threadRootId, preparedContext,
+        )
+        runStatus = await this.runRounds(
+          group, controller, threadRootId, maxRounds, context,
+        )
       } catch (error) {
         runStatus = controller.signal.aborted
           ? (controller.stopReason === 'shutdown' ? 'interrupted' : 'stopped')
@@ -578,6 +707,15 @@ class LocalWorkspaceAutoRunner {
     })()
     controller.promise = promise
     return controller
+  }
+
+  async resume(group, durable, controller) {
+    const context = await this.automaticContext(
+      group, controller, durable.threadRootId, null,
+    )
+    return this.runRounds(
+      group, controller, durable.threadRootId, durable.maxRounds, context, true,
+    )
   }
 }
 

--- a/desktop/src/local-workspace-ledger.cjs
+++ b/desktop/src/local-workspace-ledger.cjs
@@ -157,6 +157,7 @@ class LocalWorkspaceRunLedger {
       budget: controller.budget?.snapshot?.(),
       attemptHistory: controller.attemptHistory,
       continuation: controller.continuation,
+      orchestration: controller.orchestration,
       agentRuns,
     }
   }

--- a/desktop/src/local-workspace-message-submission.cjs
+++ b/desktop/src/local-workspace-message-submission.cjs
@@ -48,6 +48,8 @@ class LocalWorkspaceMessageSubmission {
     this.resetAgentSession = options.resetAgentSession
     this.refreshAgents = options.refreshAgents
     this.consumeAgentControl = options.consumeAgentControl
+    this.checkpointRun = options.checkpointRun
+    this.hasRunLedger = options.hasRunLedger || (() => false)
   }
 
   async resolveAttachments(attachmentRefs, signal) {
@@ -435,6 +437,18 @@ class LocalWorkspaceMessageSubmission {
           if (regeneration) {
             this.resetAgentSession(group, targetKinds[0], true, userMessage.id)
           }
+          reservation.orchestration = {
+            version: 1,
+            workflow: 'manual',
+            currentKind: '',
+            pendingKinds: [...targetKinds],
+            activeKinds: [...targetKinds],
+            successfulKinds: [],
+            agreementKinds: [],
+            attachmentRecipients: [],
+            totalSuccesses: 0,
+            terminalFailureOccurred: false,
+          }
           controller = this.beginRun(
             group.id, 'manual', targetKinds, threadRootId, reservation,
           )
@@ -459,6 +473,16 @@ class LocalWorkspaceMessageSubmission {
           if (controller.signal.aborted) break
           controller.currentKind = kind
           controller.progress = []
+          controller.orchestration = {
+            ...controller.orchestration,
+            currentKind: kind,
+            pendingKinds: [...pendingKinds],
+            activeKinds: [...activeKinds],
+            successfulKinds: [...successfulKinds],
+          }
+          if (this.hasRunLedger() && this.checkpointRun(group.id, controller) !== true) {
+            throw new Error('LOCAL_RUN_PERSIST_FAILED')
+          }
           this.emitChanged()
           try {
             const invocation = await this.invokeWithRecovery({
@@ -543,6 +567,16 @@ class LocalWorkspaceMessageSubmission {
           if (!controller.completedKinds.includes(kind)) controller.completedKinds.push(kind)
           controller.currentKind = ''
           controller.progress = []
+          controller.orchestration = {
+            ...controller.orchestration,
+            currentKind: '',
+            pendingKinds: [...pendingKinds],
+            activeKinds: [...activeKinds],
+            successfulKinds: [...successfulKinds],
+          }
+          if (this.hasRunLedger() && this.checkpointRun(group.id, controller) !== true) {
+            throw new Error('LOCAL_RUN_PERSIST_FAILED')
+          }
           this.emitChanged()
         }
         if (controller.signal.aborted) {

--- a/desktop/src/local-workspace-run-coordinator.cjs
+++ b/desktop/src/local-workspace-run-coordinator.cjs
@@ -85,6 +85,7 @@ class LocalWorkspaceRunCoordinator {
     controller.waitingGateIds = new Set()
     controller.attemptHistory = []
     controller.continuation = null
+    controller.orchestration = null
     return controller
   }
 
@@ -274,6 +275,7 @@ class LocalWorkspaceRunCoordinator {
     controller.currentRound = record.currentRound || 0
     controller.startedAt = record.startedAt
     controller.attemptHistory = [...(record.attemptHistory || [])]
+    controller.orchestration = record.orchestration ? structuredClone(record.orchestration) : null
     const targetKinds = new Set(controller.targetKinds)
     const latestAgentStatuses = new Map()
     for (const agentRun of Array.isArray(record.agentRuns) ? record.agentRuns : []) {
@@ -287,6 +289,13 @@ class LocalWorkspaceRunCoordinator {
       .map(([kind]) => kind)
     controller.continuation = { ...record.continuation, state: 'resuming', updatedAt: Date.now() }
     controller.waitingGateIds = new Set([record.continuation.gateId])
+    controller.harness = new RunHarness({
+      runId: record.runId,
+      groupId,
+      threadRootId: record.threadRootId,
+      targetKinds: record.targetKinds,
+      agentRuns: record.agentRuns,
+    })
     if (record.budget) {
       controller.budget = new RunBudget({
         ...record.budget,

--- a/desktop/src/local-workspace-state.cjs
+++ b/desktop/src/local-workspace-state.cjs
@@ -18,12 +18,51 @@ const FINISHED_AGENT_STATUSES = new Set([
 const FAILED_AGENT_STATUSES = new Set(['failed', 'stopped', 'timeout'])
 
 function loadWorkspaceState(storagePath) {
+  let source
   try {
-    const parsed = JSON.parse(fs.readFileSync(storagePath, 'utf8'))
-    if (![1, 2, 3].includes(parsed?.version) || !Array.isArray(parsed.groups)
-        || !Array.isArray(parsed.messages) || typeof parsed.sessions !== 'object') {
-      return emptyState()
+    source = fs.readFileSync(storagePath, 'utf8')
+  } catch (error) {
+    const missing = error?.code === 'ENOENT'
+    return {
+      state: emptyState(),
+      status: missing ? 'missing' : 'unreadable',
+      trusted: missing,
+      diagnostic: missing ? '' : 'LOCAL_WORKSPACE_STATE_UNREADABLE',
     }
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(source)
+  } catch {
+    return {
+      state: emptyState(),
+      status: 'corrupt',
+      trusted: false,
+      diagnostic: 'LOCAL_WORKSPACE_STATE_CORRUPT',
+    }
+  }
+
+  if (![1, 2, 3].includes(parsed?.version)) {
+    return {
+      state: emptyState(),
+      status: 'unsupported',
+      trusted: false,
+      diagnostic: 'LOCAL_WORKSPACE_STATE_UNSUPPORTED',
+    }
+  }
+  if (!Array.isArray(parsed.groups) || !Array.isArray(parsed.messages)
+      || !parsed.sessions || typeof parsed.sessions !== 'object'
+      || Array.isArray(parsed.sessions)) {
+    return {
+      state: emptyState(),
+      status: 'corrupt',
+      trusted: false,
+      diagnostic: 'LOCAL_WORKSPACE_STATE_CORRUPT',
+    }
+  }
+
+  try {
     const groups = parsed.groups
       .map(normalizeLoadedGroup)
       .filter(Boolean)
@@ -49,22 +88,32 @@ function loadWorkspaceState(storagePath) {
       }
     }
     return {
-      version: 3,
-      groups,
-      messages,
-      sessions,
-      sessionMeta,
-      agentPreferences: parsed.agentPreferences
-        && typeof parsed.agentPreferences === 'object' && !Array.isArray(parsed.agentPreferences)
-        ? { ...parsed.agentPreferences }
-        : {},
-      agentRuntime: parsed.agentRuntime
-        && typeof parsed.agentRuntime === 'object' && !Array.isArray(parsed.agentRuntime)
-        ? { ...parsed.agentRuntime }
-        : {},
+      state: {
+        version: 3,
+        groups,
+        messages,
+        sessions,
+        sessionMeta,
+        agentPreferences: parsed.agentPreferences
+          && typeof parsed.agentPreferences === 'object' && !Array.isArray(parsed.agentPreferences)
+          ? { ...parsed.agentPreferences }
+          : {},
+        agentRuntime: parsed.agentRuntime
+          && typeof parsed.agentRuntime === 'object' && !Array.isArray(parsed.agentRuntime)
+          ? { ...parsed.agentRuntime }
+          : {},
+      },
+      status: 'ready',
+      trusted: true,
+      diagnostic: '',
     }
   } catch {
-    return emptyState()
+    return {
+      state: emptyState(),
+      status: 'corrupt',
+      trusted: false,
+      diagnostic: 'LOCAL_WORKSPACE_STATE_CORRUPT',
+    }
   }
 }
 
@@ -139,6 +188,7 @@ function durableWaitingRunSnapshots({ state, runLedger, pendingGates, liveRunIds
 
 function workspaceSnapshot({
   detectedAgents, state, preparingRuns, activeRuns, humanGateCoordinator, runLedger,
+  workspaceRecovery,
 }) {
   const busyEntries = [
     ...[...preparingRuns.entries()].map(entry => [...entry, 'preparing']),
@@ -161,6 +211,13 @@ function workspaceSnapshot({
     agents: detectedAgents.map(({ executable, ...agent }) => agent),
     groups: state.groups,
     messages: state.messages,
+    ...(workspaceRecovery?.trusted === false ? {
+      recovery: {
+        state: 'read-only',
+        status: workspaceRecovery.status,
+        diagnostic: workspaceRecovery.diagnostic,
+      },
+    } : {}),
     runningGroupIds: [...new Set([
       ...busyEntries.map(([groupId]) => groupId),
       ...durableRuns.map(run => run.groupId),

--- a/desktop/src/local-workspace.cjs
+++ b/desktop/src/local-workspace.cjs
@@ -88,6 +88,8 @@ class LocalWorkspace extends EventEmitter {
     this.createId = options.createId || randomUUID
     this.createRunId = options.createRunId || randomUUID
     this.runLedger = options.runLedger || null
+    this.workspaceRecovery = this.load()
+    this.state = this.workspaceRecovery.state
     const privateRoot = path.join(path.dirname(this.storagePath), 'roundrelay-private')
     this.contentBlobStore = options.contentBlobStore || new ContentBlobStore({
       rootPath: path.join(privateRoot, 'content-blobs'),
@@ -117,16 +119,17 @@ class LocalWorkspace extends EventEmitter {
       contentBlobStore: this.contentBlobStore,
       contextPackStore: this.contextPackStore,
     })
-    this.runLedger?.reconcileContextPacks?.(
-      contextPackId => this.contextPackStore.get(contextPackId),
-    )
+    if (this.workspaceRecovery.trusted) {
+      this.runLedger?.reconcileContextPacks?.(
+        contextPackId => this.contextPackStore.get(contextPackId),
+      )
+    }
     this.detectedAgents = []
     this.preparingRuns = new Map()
     this.activeRuns = new Map()
     this.runCheckpointTimers = new Map()
     this.humanGateWaitTails = new Map()
     this.shuttingDown = false
-    this.state = this.load()
     this.agentCatalog = new LocalWorkspaceAgentCatalog({
       state: () => this.state,
       detectedAgents: () => this.detectedAgents,
@@ -285,10 +288,12 @@ class LocalWorkspace extends EventEmitter {
       refreshAgents: () => this.refreshAgents(),
       consumeAgentControl: (...args) => this.runCoordinator.consumeAgentControl(...args),
     })
-    this.humanGateCoordinator.reconcileDecisions?.()
-    this.restoreInterruptedRuns()
-    this.humanGateCoordinator.reconcileOrphans?.()
-    this.resumeReadyHumanGates()
+    if (this.workspaceRecovery.trusted) {
+      this.humanGateCoordinator.reconcileDecisions?.()
+      this.restoreInterruptedRuns()
+      this.humanGateCoordinator.reconcileOrphans?.()
+      this.resumeReadyHumanGates()
+    }
   }
 
   agentLabel(kind) {
@@ -300,6 +305,9 @@ class LocalWorkspace extends EventEmitter {
   }
 
   save() {
+    if (!this.workspaceRecovery.trusted) {
+      throw new Error(this.workspaceRecovery.diagnostic || 'LOCAL_WORKSPACE_STATE_UNTRUSTED')
+    }
     saveWorkspaceState(this.storagePath, this.state)
   }
 

--- a/desktop/src/local-workspace.cjs
+++ b/desktop/src/local-workspace.cjs
@@ -287,6 +287,8 @@ class LocalWorkspace extends EventEmitter {
       resetAgentSession: (...args) => this.resetAgentSession(...args),
       refreshAgents: () => this.refreshAgents(),
       consumeAgentControl: (...args) => this.runCoordinator.consumeAgentControl(...args),
+      checkpointRun: (...args) => this.checkpointRun(...args),
+      hasRunLedger: () => Boolean(this.runLedger),
     })
     if (this.workspaceRecovery.trusted) {
       this.humanGateCoordinator.reconcileDecisions?.()
@@ -551,6 +553,35 @@ class LocalWorkspace extends EventEmitter {
     return !durable.threadRootId || durable.taskId === durable.threadRootId
   }
 
+  canResumeOrchestration(durable, workflow) {
+    const cursor = durable?.orchestration
+    const continuation = durable?.continuation
+    if (durable?.mode !== workflow || cursor?.version !== 1 || cursor.workflow !== workflow
+        || cursor.currentKind !== continuation?.agentKind
+        || !cursor.activeKinds.includes(cursor.currentKind)) return false
+    const targetKinds = Array.isArray(durable.targetKinds) ? durable.targetKinds : []
+    if (workflow === 'auto' && (
+      durable.currentRound < 1 || continuation?.round !== durable.currentRound
+    )) return false
+    if (workflow === 'manual' && continuation?.round !== 0) return false
+    return cursor.activeKinds.length > 0
+      && cursor.activeKinds.every(kind => targetKinds.includes(kind))
+      && cursor.pendingKinds.every(kind => cursor.activeKinds.includes(kind))
+      && !cursor.pendingKinds.includes(cursor.currentKind)
+      && !cursor.successfulKinds.includes(cursor.currentKind)
+      && cursor.successfulKinds.every(kind => cursor.activeKinds.includes(kind))
+      && cursor.pendingKinds.every(kind => !cursor.successfulKinds.includes(kind))
+      && cursor.agreementKinds.every(kind => cursor.successfulKinds.includes(kind))
+  }
+
+  canResumeManualOrchestration(durable) {
+    return this.canResumeOrchestration(durable, 'manual')
+  }
+
+  canResumeAutoOrchestration(durable) {
+    return this.canResumeOrchestration(durable, 'auto')
+  }
+
   async replayAgentSlot(group, durable, controller, gate, decision, request) {
     if (!['budget', 'permission'].includes(gate?.type)) {
       throw new Error('LOCAL_RUN_CONTINUATION_INVALID')
@@ -571,11 +602,12 @@ class LocalWorkspace extends EventEmitter {
     const knowledge = await this.validateKnowledgeBaseSelectionsFn(
       [durable.continuation.agentKind], message.knowledgeBaseHints || [],
     )
+    const activeKinds = controller.orchestration?.activeKinds || durable.targetKinds
     const recovered = await this.autoRunner.invokeWithUnauthorizedRecovery({
       group,
       kind: durable.continuation.agentKind,
       controller,
-      activeKinds: durable.targetKinds,
+      activeKinds,
       threadRootId: durable.threadRootId,
       context: {
         attachments: attachments.map(attachment => attachment.path),
@@ -608,6 +640,106 @@ class LocalWorkspace extends EventEmitter {
     return recovered.result
   }
 
+  async continueManualOrchestration(group, durable, controller) {
+    const cursor = controller.orchestration
+    const message = this.state.messages.find(candidate => (
+      candidate.groupId === group.id
+      && candidate.role === 'user'
+      && [durable.taskId, durable.threadRootId].includes(candidate.id)
+    ))
+    if (!message || cursor?.version !== 1 || cursor.workflow !== 'manual'
+        || cursor.currentKind || cursor.pendingKinds.some(kind => !cursor.activeKinds.includes(kind))) {
+      throw new Error('LOCAL_RUN_CONTINUATION_INVALID')
+    }
+    const attachments = await this.resolveAttachments(message.attachments || [])
+    const activeKinds = [...cursor.activeKinds]
+    const successfulKinds = new Set(cursor.successfulKinds)
+    const pendingKinds = [...cursor.pendingKinds]
+    const reportedFailures = new Set()
+
+    while (pendingKinds.length) {
+      const kind = pendingKinds.shift()
+      if (!activeKinds.includes(kind) || controller.signal.aborted) continue
+      controller.currentKind = kind
+      controller.progress = []
+      controller.orchestration = {
+        ...controller.orchestration,
+        currentKind: kind,
+        pendingKinds: [...pendingKinds],
+        successfulKinds: [...successfulKinds],
+      }
+      if (this.checkpointRun(group.id, controller) !== true) {
+        throw new Error('LOCAL_RUN_PERSIST_FAILED')
+      }
+      this.emitChanged()
+      try {
+        const skills = await this.validateSkillSelectionsFn(
+          kind,
+          (message.skillHints || []).filter(skill => skill.targetKind === kind),
+        )
+        const knowledge = await this.validateKnowledgeBaseSelectionsFn(
+          [kind],
+          (message.knowledgeBaseHints || []).filter(source => source.targetKinds?.includes(kind))
+            .map(source => ({ ...source, targetKinds: [kind] })),
+        )
+        const invocation = await this.autoRunner.invokeWithUnauthorizedRecovery({
+          group,
+          kind,
+          controller,
+          activeKinds,
+          threadRootId: durable.threadRootId,
+          context: {
+            attachments: attachments.map(attachment => attachment.path),
+            attachmentSnapshots: attachments,
+            skillHints: skills,
+            knowledgeBaseHints: knowledge,
+            contextOptions: { focusUserMessageId: message.id },
+          },
+          reportedFailures,
+          mode: 'manual',
+        })
+        if (!invocation?.result) throw invocation?.error || new Error('LOCAL_AGENT_UNKNOWN_FAILURE')
+        successfulKinds.add(kind)
+      } catch (error) {
+        if (controller.signal.aborted) {
+          this.recordAgentInterruption(
+            group.id,
+            kind,
+            error,
+            durable.threadRootId,
+            controller.stopReason === 'shutdown' ? 'interrupted' : 'stopped',
+            reportedFailures,
+          )
+          if (!controller.completedKinds.includes(kind)) controller.completedKinds.push(kind)
+          break
+        }
+        this.recordAgentFailure(group.id, kind, error, durable.threadRootId, reportedFailures)
+        if (!controller.failedKinds.includes(kind)) controller.failedKinds.push(kind)
+        successfulKinds.delete(kind)
+      }
+      if (!controller.completedKinds.includes(kind)) controller.completedKinds.push(kind)
+      controller.currentKind = ''
+      controller.progress = []
+      controller.orchestration = {
+        ...controller.orchestration,
+        currentKind: '',
+        pendingKinds: [...pendingKinds],
+        successfulKinds: [...successfulKinds],
+      }
+      if (this.checkpointRun(group.id, controller) !== true) {
+        throw new Error('LOCAL_RUN_PERSIST_FAILED')
+      }
+      this.emitChanged()
+    }
+
+    if (controller.signal.aborted) {
+      return controller.stopReason === 'shutdown' ? 'interrupted' : 'stopped'
+    }
+    const successCount = activeKinds.filter(kind => successfulKinds.has(kind)).length
+    if (!successCount) return 'failed'
+    return successCount === activeKinds.length ? 'completed' : 'partial'
+  }
+
   async resumeHumanGateDecision(gate, decision) {
     const durable = this.runLedger?.get?.(gate.runId)
     if (!this.canResumeHumanGateRecord(durable, gate)) {
@@ -617,15 +749,20 @@ class LocalWorkspace extends EventEmitter {
     try {
       controller = this.runCoordinator.resume(durable)
       const group = this.getGroup(durable.groupId)
+      const resumableManual = this.canResumeManualOrchestration(durable)
+      const resumableAuto = this.canResumeAutoOrchestration(durable)
       if (durable.continuation.resumeKind === 'agent_slot'
           && decision.status === 'approved'
-          && !this.canFinalizeReplayedAgentSlot(durable)) {
+          && !this.canFinalizeReplayedAgentSlot(durable)
+          && !resumableManual
+          && !resumableAuto) {
         throw new Error('LOCAL_RUN_ORCHESTRATION_RESUME_UNAVAILABLE')
       }
       if (durable.continuation.resumeKind === 'role_review_decision') {
         throw new Error('LOCAL_WORKFLOW_UNSUPPORTED')
       }
       const request = this.humanGateStore.request(gate.gateId)
+      let replayedResult = null
       if (gate.type === 'permission') {
         if (decision.status === 'rejected') {
           this.resetAgentSession(group, durable.continuation.agentKind, true, durable.taskId)
@@ -636,14 +773,49 @@ class LocalWorkspace extends EventEmitter {
           this.finishRun(durable.groupId, controller, 'stopped')
           return
         }
-        await this.replayAgentSlot(group, durable, controller, gate, decision, request)
+        replayedResult = await this.replayAgentSlot(
+          group, durable, controller, gate, decision, request,
+        )
       } else if (gate.type === 'budget' && decision.status !== 'approved') {
         throw new Error('LOCAL_BUDGET_REJECTED')
       } else {
-        await this.replayAgentSlot(group, durable, controller, gate, decision, request)
+        replayedResult = await this.replayAgentSlot(
+          group, durable, controller, gate, decision, request,
+        )
       }
-      this.completeHumanGateContinuation(durable.runId, gate.gateId, 'completed')
-      this.finishRun(durable.groupId, controller, 'completed')
+      if (resumableManual || resumableAuto) {
+        const successfulKinds = new Set(controller.orchestration.successfulKinds)
+        successfulKinds.add(durable.continuation.agentKind)
+        controller.currentKind = ''
+        controller.orchestration = {
+          ...controller.orchestration,
+          currentKind: '',
+          successfulKinds: [...successfulKinds],
+          ...(resumableAuto ? {
+            agreementKinds: replayedResult?.consensus
+              ? [...new Set([
+                  ...controller.orchestration.agreementKinds,
+                  durable.continuation.agentKind,
+                ])]
+              : controller.orchestration.agreementKinds.filter(
+                  kind => kind !== durable.continuation.agentKind,
+                ),
+            attachmentRecipients: [...new Set([
+              ...controller.orchestration.attachmentRecipients,
+              durable.continuation.agentKind,
+            ])],
+          } : {}),
+        }
+      }
+      if (!this.completeHumanGateContinuation(durable.runId, gate.gateId, 'completed')) {
+        throw new Error('LOCAL_RUN_PERSIST_FAILED')
+      }
+      const finalStatus = resumableManual
+        ? await this.continueManualOrchestration(group, durable, controller)
+        : (resumableAuto
+            ? await this.autoRunner.resume(group, durable, controller)
+            : 'completed')
+      this.finishRun(durable.groupId, controller, finalStatus)
     } catch (error) {
       if (controller) {
         if (controller.signal.aborted && controller.stopReason === 'shutdown') {

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -446,6 +446,7 @@ function createWorkspace() {
     runAgent: async (agent, prompt, workdir, options = {}) => {
       if (customAgentStore.has(agent.kind)) {
         return customAgentStore.run(agent.kind, prompt, workdir, {
+          sandbox: options.sandbox,
           signal: options.signal,
           onProgress: options.onProgress,
           onEvent: options.onEvent,

--- a/desktop/src/run-harness.cjs
+++ b/desktop/src/run-harness.cjs
@@ -58,8 +58,45 @@ class RunHarness {
     this.maxAgentRuns = Math.max(1, boundedNumber(
       options.maxAgentRuns, DEFAULT_MAX_AGENT_RUNS, 512,
     ))
-    this.sequence = 0
-    this.agentRuns = []
+    this.agentRuns = (Array.isArray(options.agentRuns) ? options.agentRuns : [])
+      .slice(-this.maxAgentRuns)
+      .map((run) => {
+        const events = Array.isArray(run?.events) ? run.events.map(event => ({ ...event })) : []
+        const eventCursor = boundedNumber(
+          run?.eventCursor,
+          events.reduce((highest, event) => Math.max(
+            highest, boundedNumber(event?.seq, 0, 1000000000),
+          ), 0),
+          1000000000,
+        )
+        const eventIndexes = new Map()
+        events.forEach((event, index) => {
+          const key = lifecycleEventKey(event)
+          if (key) eventIndexes.set(key, index)
+        })
+        return {
+          agentRunId: cleanId(run?.agentRunId),
+          kind: cleanId(run?.kind),
+          round: boundedNumber(run?.round, 0, 100000),
+          status: cleanStatus(run?.status, 'interrupted'),
+          output: cleanText(run?.output, this.maxOutputChars, { redactPaths: false }),
+          events,
+          eventIndexes,
+          sourceMessageIds: normalizeSourceMessageIds(run?.sourceMessageIds),
+          startedAt: safeTimestamp(run?.startedAt, 0),
+          lastActivityAt: safeTimestamp(run?.lastActivityAt, 0),
+          silent: run?.silent === true,
+          truncated: run?.truncated === true,
+          seenSeqs: events.map(event => boundedNumber(event?.seq, 0, 1000000000)).filter(Boolean),
+          eventCursor,
+          context: normalizeContextStats(run?.context),
+        }
+      })
+      .filter(run => run.agentRunId && run.kind && this.targetKinds.includes(run.kind))
+    this.sequence = this.agentRuns.reduce((highest, run) => Math.max(
+      highest,
+      run.eventCursor,
+    ), 0)
   }
 
   timestamp() {
@@ -93,7 +130,7 @@ class RunHarness {
   }
 
   nextEvent(run, event) {
-    return {
+    const next = {
       runId: this.runId,
       agentRunId: run.agentRunId,
       groupId: this.groupId,
@@ -105,6 +142,8 @@ class RunHarness {
       status: cleanStatus(event.status, run.status),
       ...event,
     }
+    run.eventCursor = next.seq
+    return next
   }
 
   beginAgent(kind, round = 0, sourceMessageIds = []) {
@@ -132,6 +171,7 @@ class RunHarness {
       silent: false,
       truncated: false,
       seenSeqs: [],
+      eventCursor: 0,
       context: {},
     }
     this.agentRuns.push(run)
@@ -269,6 +309,7 @@ class RunHarness {
       silent: run.silent,
       truncated: run.truncated,
       seenSeqs: [...run.seenSeqs],
+      eventCursor: run.eventCursor,
       context: { ...run.context },
     }))
   }

--- a/desktop/src/run-journal.cjs
+++ b/desktop/src/run-journal.cjs
@@ -12,7 +12,7 @@ const RUN_FIELDS = new Set([
   'runId', 'taskId', 'contextPackId', 'contextPackState', 'groupId', 'threadRootId', 'mode',
   'targetKinds', 'status', 'createdAt', 'startedAt', 'updatedAt', 'finishedAt',
   'reason', 'permissionMode', 'currentRound', 'maxRounds', 'unlimitedRounds',
-  'budget', 'attemptHistory', 'continuation', 'remoteJob', 'agentRuns',
+  'budget', 'attemptHistory', 'continuation', 'orchestration', 'remoteJob', 'agentRuns',
 ])
 const AGENT_RUN_FIELDS = new Set([
   'agentRunId', 'kind', 'round', 'status', 'reason', 'sourceMessageIds',

--- a/desktop/src/run-ledger-records.cjs
+++ b/desktop/src/run-ledger-records.cjs
@@ -55,6 +55,12 @@ const CONTINUATION_RESUME_KINDS = new Set(['agent_slot', 'role_review_decision']
 const CONTINUATION_STATES = new Set([
   'pending', 'ready', 'resuming', 'completed', 'failed', 'cancelled',
 ])
+const ORCHESTRATION_FIELDS = new Set([
+  'version', 'workflow', 'currentKind', 'pendingKinds', 'activeKinds',
+  'successfulKinds', 'agreementKinds', 'attachmentRecipients',
+  'totalSuccesses', 'terminalFailureOccurred',
+])
+const ORCHESTRATION_WORKFLOWS = new Set(['manual', 'auto'])
 
 const RUN_STATUSES = new Set([
   'preparing', 'queued', 'running', 'waiting', 'reconciling',
@@ -351,6 +357,35 @@ function normalizeContinuation(input) {
   }
 }
 
+function normalizeOrchestration(input) {
+  if (input == null) return null
+  if (!isRecord(input) || Object.keys(input).some(field => !ORCHESTRATION_FIELDS.has(field))) {
+    return undefined
+  }
+  const version = boundedNumber(input.version, 0, 100)
+  const workflow = String(input.workflow || '')
+  const currentKind = cleanId(input.currentKind)
+  const pendingKinds = normalizeKinds(input.pendingKinds)
+  const activeKinds = normalizeKinds(input.activeKinds)
+  const successfulKinds = normalizeKinds(input.successfulKinds)
+  const agreementKinds = normalizeKinds(input.agreementKinds)
+  const attachmentRecipients = normalizeKinds(input.attachmentRecipients)
+  const totalSuccesses = boundedNumber(input.totalSuccesses, 0, 1000000)
+  if (version !== 1 || !ORCHESTRATION_WORKFLOWS.has(workflow)) return undefined
+  return {
+    version,
+    workflow,
+    currentKind,
+    pendingKinds,
+    activeKinds,
+    successfulKinds,
+    agreementKinds,
+    attachmentRecipients,
+    totalSuccesses,
+    terminalFailureOccurred: input.terminalFailureOccurred === true,
+  }
+}
+
 function hasValidStoredRecordShape(input) {
   if (!isRecord(input)) return false
   if (!hasStoredFieldTypes(input, [
@@ -377,6 +412,11 @@ function hasValidStoredRecordShape(input) {
     const continuation = normalizeContinuation(input.continuation)
     if (continuation === undefined
         || canonicalJson(continuation) !== canonicalJson(input.continuation)) return false
+  }
+  if (hasOwn(input, 'orchestration')) {
+    const orchestration = normalizeOrchestration(input.orchestration)
+    if (orchestration === undefined
+        || canonicalJson(orchestration) !== canonicalJson(input.orchestration)) return false
   }
   if (hasOwn(input, 'remoteJob')) {
     if (!isRecord(input.remoteJob)
@@ -414,6 +454,15 @@ function hasValidStoredRecordShape(input) {
   if (!Array.isArray(input.agentRuns)) return false
 
   const targetKinds = normalizeKinds(input.targetKinds)
+  const orchestration = normalizeOrchestration(input.orchestration)
+  if (orchestration && [
+    orchestration.currentKind,
+    ...orchestration.pendingKinds,
+    ...orchestration.activeKinds,
+    ...orchestration.successfulKinds,
+    ...orchestration.agreementKinds,
+    ...orchestration.attachmentRecipients,
+  ].filter(Boolean).some(kind => !targetKinds.includes(kind))) return false
   const parent = {
     runId: cleanId(input.runId),
     groupId: cleanGroupId(input.groupId),
@@ -640,6 +689,18 @@ function normalizeRecord(input, options = {}) {
   const rawContinuation = selectedValue(input, existing, 'continuation')
   const continuation = normalizeContinuation(rawContinuation)
   if (continuation === undefined) return null
+  const rawOrchestration = selectedValue(input, existing, 'orchestration')
+  const orchestration = normalizeOrchestration(rawOrchestration)
+  if (orchestration === undefined) return null
+  if (orchestration && orchestration.workflow !== mode) return null
+  if (orchestration && [
+    orchestration.currentKind,
+    ...orchestration.pendingKinds,
+    ...orchestration.activeKinds,
+    ...orchestration.successfulKinds,
+    ...orchestration.agreementKinds,
+    ...orchestration.attachmentRecipients,
+  ].filter(Boolean).some(kind => !targetKinds.includes(kind))) return null
 
   const record = {
     runId,
@@ -664,6 +725,7 @@ function normalizeRecord(input, options = {}) {
   }
   if (budget) record.budget = budget
   if (continuation) record.continuation = continuation
+  if (orchestration) record.orchestration = orchestration
   if (remoteJob) record.remoteJob = remoteJob
   if (TERMINAL_STATUSES.has(status)) {
     record.finishedAt = safeTimestamp(

--- a/desktop/src/run-ledger.cjs
+++ b/desktop/src/run-ledger.cjs
@@ -98,6 +98,7 @@ function journalRunSignature(record) {
     budget: record.budget || null,
     attemptHistory: record.attemptHistory,
     continuation: record.continuation || null,
+    orchestration: record.orchestration || null,
     remoteJob: record.remoteJob || null,
   })
 }
@@ -133,6 +134,7 @@ function journalRun(record, existing = null, includeAllAgents = false) {
     agentRuns,
   }
   if (record.continuation) run.continuation = record.continuation
+  if (record.orchestration) run.orchestration = record.orchestration
   if (record.budget) run.budget = record.budget
   if (record.finishedAt != null) run.finishedAt = record.finishedAt
   if (record.remoteJob) run.remoteJob = record.remoteJob

--- a/desktop/test/custom-agent-store.test.cjs
+++ b/desktop/test/custom-agent-store.test.cjs
@@ -127,6 +127,7 @@ test('runs a Custom Agent without a shell and redacts its private executable pat
   }
 
   const result = await store.run('custom-0123456789abcdef', 'Review this change', '/tmp', {
+    sandbox: 'workspace-write',
     spawnFn,
     attachments: [attachmentPath],
     onOutboundPayload: (payload) => {
@@ -167,6 +168,24 @@ test('runs a Custom Agent without a shell and redacts its private executable pat
   assert.equal(result.outcome, 'partial')
 })
 
+test('fails closed before spawning a Custom Agent in read-only mode', async (t) => {
+  const { executable, store } = fixture(t)
+  store.create({ label: 'Review Agent', args: [], promptMode: 'stdin' }, executable)
+  let spawnCalls = 0
+
+  await assert.rejects(
+    store.run('custom-0123456789abcdef', 'Do not write', '/tmp', {
+      sandbox: 'read-only',
+      spawnFn: () => {
+        spawnCalls += 1
+        throw new Error('process must not spawn')
+      },
+    }),
+    { code: 'CUSTOM_AGENT_READ_ONLY_UNSUPPORTED' },
+  )
+  assert.equal(spawnCalls, 0)
+})
+
 test('captures the exact Custom Agent stdin before process spawn', async (t) => {
   const { directory, executable, store } = fixture(t)
   store.create({
@@ -197,6 +216,7 @@ test('captures the exact Custom Agent stdin before process spawn', async (t) => 
     'Review stdin payload',
     directory,
     {
+      sandbox: 'workspace-write',
       spawnFn: (command, args, options) => {
         spawnCalled = true
         invocation = { command, args, options }
@@ -233,6 +253,7 @@ test('Custom Agent outbound callback failure prevents process spawn', async (t) 
 
   await assert.rejects(
     store.run('custom-0123456789abcdef', 'must not be delivered', '/tmp', {
+      sandbox: 'workspace-write',
       spawnFn: () => {
         spawnCalls += 1
         throw new Error('process must not spawn')
@@ -257,6 +278,7 @@ test('cancels the Custom Agent process through the shared AbortSignal', async (t
   }
   const controller = new AbortController()
   const run = store.run('custom-0123456789abcdef', 'Review this change', '/tmp', {
+    sandbox: 'workspace-write',
     signal: controller.signal,
     spawnFn: () => child,
   })

--- a/desktop/test/local-workspace-harness.test.cjs
+++ b/desktop/test/local-workspace-harness.test.cjs
@@ -1671,6 +1671,37 @@ test('conversation deletion remains retryable when a corrupt Run Ledger blocks c
   assert.equal(deleteAttempts, 2)
 })
 
+test('malformed workspace state enters read-only recovery without touching valid Ledger data', (t) => {
+  const { directory, options } = fixture()
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }))
+  fs.writeFileSync(options.storagePath, '{partially-written')
+  const ledgerCalls = []
+  options.runLedger = {
+    reconcileContextPacks: () => ledgerCalls.push('reconcileContextPacks'),
+    recoverInterrupted: () => ledgerCalls.push('recoverInterrupted'),
+    list: () => [{ runId: 'run-1', groupId: 'group-1', status: 'completed' }],
+    deleteGroup: groupId => ledgerCalls.push(`deleteGroup:${groupId}`),
+  }
+
+  const workspace = new LocalWorkspace(options)
+  const firstSnapshot = workspace.snapshot()
+  const restarted = new LocalWorkspace(options)
+
+  assert.deepEqual(ledgerCalls, [])
+  assert.deepEqual(firstSnapshot.recovery, {
+    state: 'read-only',
+    status: 'corrupt',
+    diagnostic: 'LOCAL_WORKSPACE_STATE_CORRUPT',
+  })
+  assert.deepEqual(restarted.snapshot().recovery, firstSnapshot.recovery)
+  assert.equal(fs.readFileSync(options.storagePath, 'utf8'), '{partially-written')
+  assert.throws(
+    () => workspace.save(),
+    { message: 'LOCAL_WORKSPACE_STATE_CORRUPT' },
+  )
+  assert.equal(fs.readFileSync(options.storagePath, 'utf8'), '{partially-written')
+})
+
 test('conversation state rolls back when workspace deletion persistence fails', async (t) => {
   const { directory, options } = fixture()
   t.after(() => fs.rmSync(directory, { recursive: true, force: true }))

--- a/desktop/test/local-workspace-human-gate-recovery.test.cjs
+++ b/desktop/test/local-workspace-human-gate-recovery.test.cjs
@@ -36,6 +36,17 @@ async function waitForRunStatus(ledger, runId, status, timeoutMs = 5000) {
   throw new Error(`TEST_RUN_STATUS_TIMEOUT:${runId}:${status}`)
 }
 
+async function waitForTerminalRun(ledger, runId, timeoutMs = 5000) {
+  const terminal = new Set(['completed', 'partial', 'failed', 'stopped', 'timeout', 'round-limit'])
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const record = ledger.get(runId)
+    if (terminal.has(record?.status)) return record
+    await new Promise(resolve => setTimeout(resolve, 20))
+  }
+  throw new Error(`TEST_RUN_TERMINAL_TIMEOUT:${runId}`)
+}
+
 async function stoppedBudgetGate(options, directory, text) {
   const workspace = new LocalWorkspace(options)
   await workspace.refreshAgents()
@@ -75,6 +86,141 @@ function removeContextPack(workspace, contextPackId) {
     hash.slice(0, 2),
     `${contextPackId}.json`,
   ))
+}
+
+async function verifyAutomaticGateRecovery(t, gateIndex) {
+  const { directory, options } = fixture()
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }))
+  const ledgerPath = path.join(directory, 'run-ledger.json')
+  const ledger = new RunLedger({ storagePath: ledgerPath })
+  const targetOrders = [
+    ['kimi', 'codex', 'workbuddy'],
+    ['codex', 'kimi', 'workbuddy'],
+    ['codex', 'workbuddy', 'kimi'],
+  ]
+  const targetKinds = targetOrders[gateIndex]
+  const maxRounds = gateIndex === 1 ? 2 : 1
+  const invokedKinds = []
+  const completedTurns = new Map()
+  let appliedDecisions = 0
+  options.runLedger = ledger
+  options.runAgent = async (agent, _prompt, _workdir, runOptions) => {
+    invokedKinds.push(agent.kind)
+    if (agent.kind !== 'kimi') {
+      const completed = (completedTurns.get(agent.kind) || 0) + 1
+      completedTurns.set(agent.kind, completed)
+      const consensus = maxRounds > 1 && completed === maxRounds
+        ? '\n[[ROUNDRELAY_CONSENSUS:agree]]'
+        : ''
+      return {
+        text: `${agent.kind} completed its automatic slot${consensus}`,
+        sessionRef: `${agent.kind}-auto`,
+      }
+    }
+    if (appliedDecisions > 0) {
+      const completed = (completedTurns.get(agent.kind) || 0) + 1
+      completedTurns.set(agent.kind, completed)
+      const consensus = maxRounds > 1 && completed === maxRounds
+        ? '\n[[ROUNDRELAY_CONSENSUS:agree]]'
+        : ''
+      return {
+        text: `Kimi completed its later automatic slot${consensus}`,
+        sessionRef: 'kimi-auto-gate-session',
+      }
+    }
+    await runOptions.onSessionRef('kimi-auto-gate-session', { transport: 'acp' })
+    const decision = await runOptions.onPermissionRequest({
+      options: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Reject once', kind: 'reject_once' },
+      ],
+      operation: { kind: 'write', path: `auto-slot-${gateIndex}.txt` },
+    }, { signal: runOptions.signal })
+    appliedDecisions += 1
+    const completed = (completedTurns.get(agent.kind) || 0) + 1
+    completedTurns.set(agent.kind, completed)
+    const consensus = maxRounds > 1 && completed === maxRounds
+      ? '\n[[ROUNDRELAY_CONSENSUS:agree]]'
+      : ''
+    return {
+      text: `Kimi resumed:${decision.optionId}${consensus}`,
+      sessionRef: 'kimi-auto-gate-session',
+    }
+  }
+  const workspace = new LocalWorkspace(options)
+  await workspace.refreshAgents()
+  const group = workspace.createGroup({
+    name: `Automatic Gate recovery ${gateIndex}`,
+    agentKinds: targetKinds,
+    workdir: directory,
+    allowWrite: true,
+  })
+  const gatePromise = pendingGate(workspace)
+  await workspace.sendMessage({
+    groupId: group.id,
+    text: `Resume automatic slot ${gateIndex} after restart`,
+    mode: 'auto',
+    maxRounds,
+    targetKinds,
+  })
+  const pending = await gatePromise
+  await workspace.stopAll()
+
+  const waiting = new RunLedger({ storagePath: ledgerPath }).get(pending.runId)
+  assert.equal(waiting.currentRound, 1)
+  assert.deepEqual(waiting.orchestration, {
+    version: 1,
+    workflow: 'auto',
+    currentKind: 'kimi',
+    pendingKinds: targetKinds.slice(gateIndex + 1),
+    activeKinds: targetKinds,
+    successfulKinds: targetKinds.slice(0, gateIndex),
+    agreementKinds: [],
+    attachmentRecipients: [],
+    totalSuccesses: 0,
+    terminalFailureOccurred: false,
+  })
+
+  const restartedLedger = new RunLedger({ storagePath: ledgerPath })
+  const restarted = new LocalWorkspace({ ...options, runLedger: restartedLedger })
+  await restarted.refreshAgents()
+  restarted.decideHumanGate(pending.gateId, {
+    status: 'approved', optionId: 'allow-once', actorId: 'local-user',
+  })
+  const terminal = await waitForTerminalRun(restartedLedger, pending.runId)
+
+  assert.deepEqual(
+    { status: terminal.status, reason: terminal.reason },
+    { status: maxRounds > 1 ? 'completed' : 'round-limit', reason: '' },
+  )
+  assert.deepEqual(invokedKinds, [
+    ...targetKinds.slice(0, gateIndex + 1),
+    'kimi',
+    ...targetKinds.slice(gateIndex + 1),
+    ...(maxRounds > 1 ? targetKinds : []),
+  ])
+  assert.equal(appliedDecisions, 1)
+  assert.equal(terminal.continuation.state, 'completed')
+  assert.deepEqual(terminal.orchestration.pendingKinds, [])
+  assert.deepEqual(terminal.orchestration.successfulKinds.sort(), [...targetKinds].sort())
+  assert.equal(terminal.orchestration.totalSuccesses, targetKinds.length * maxRounds)
+  for (const kind of targetKinds.slice(0, gateIndex)) {
+    assert.equal(restarted.snapshot().messages.filter(message => (
+      message.role === 'agent' && message.agentKind === kind
+    )).length, maxRounds)
+  }
+  const sequences = terminal.agentRuns.flatMap(run => run.events.map(event => event.seq))
+  assert.deepEqual(sequences, [...sequences].sort((left, right) => left - right))
+  assert.equal(new Set(sequences).size, sequences.length)
+
+  const invocationCount = invokedKinds.length
+  const secondRestart = new LocalWorkspace({
+    ...options,
+    runLedger: new RunLedger({ storagePath: ledgerPath }),
+  })
+  await secondRestart.refreshAgents()
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(invokedKinds.length, invocationCount)
 }
 
 test('legacy Role Review continuations fail closed without reading workflow data', async (t) => {
@@ -160,8 +306,12 @@ test('restart resumes a durable Gate decision whose continuation checkpoint stay
   const restartedLedger = new RunLedger({ storagePath: ledgerPath })
   const restarted = new LocalWorkspace({ ...options, runLedger: restartedLedger })
   await restarted.refreshAgents()
-  const completed = await waitForRunStatus(restartedLedger, pending.runId, 'completed')
+  const completed = await waitForTerminalRun(restartedLedger, pending.runId)
 
+  assert.deepEqual(
+    { status: completed.status, reason: completed.reason },
+    { status: 'completed', reason: '' },
+  )
   assert.equal(invocations, 1)
   assert.equal(completed.continuation.state, 'completed')
   assert.equal(restarted.snapshot().messages.some(message => (
@@ -179,7 +329,7 @@ test('restart resumes a durable Gate decision whose continuation checkpoint stay
   assert.equal(invocations, 1)
 })
 
-test('restart fails a non-final Agent Gate closed instead of completing the remaining slots', async (t) => {
+test('restart resumes a first-slot Agent Gate and completes the remaining manual slots', async (t) => {
   const { directory, options } = fixture()
   t.after(() => fs.rmSync(directory, { recursive: true, force: true }))
   const ledgerPath = path.join(directory, 'run-ledger.json')
@@ -188,6 +338,9 @@ test('restart fails a non-final Agent Gate closed instead of completing the rema
   options.runLedger = ledger
   options.runAgent = async (agent, _prompt, _workdir, runOptions) => {
     invokedKinds.push(agent.kind)
+    if (agent.kind === 'hermes') {
+      return { text: 'Hermes completed the remaining slot', sessionRef: 'hermes-resumed-session' }
+    }
     assert.equal(agent.kind, 'codex')
     await runOptions.onSessionRef('codex-non-final-session', { transport: 'acp' })
     const decision = await runOptions.onPermissionRequest({
@@ -220,17 +373,114 @@ test('restart fails a non-final Agent Gate closed instead of completing the rema
   const restartedLedger = new RunLedger({ storagePath: ledgerPath })
   const restarted = new LocalWorkspace({ ...options, runLedger: restartedLedger })
   await restarted.refreshAgents()
+  assert.deepEqual(restartedLedger.get(pending.runId).orchestration, {
+    version: 1,
+    workflow: 'manual',
+    currentKind: 'codex',
+    pendingKinds: ['hermes'],
+    activeKinds: ['codex', 'hermes'],
+    successfulKinds: [],
+    agreementKinds: [],
+    attachmentRecipients: [],
+    totalSuccesses: 0,
+    terminalFailureOccurred: false,
+  })
   restarted.decideHumanGate(pending.gateId, {
     status: 'approved', optionId: 'allow-once', actorId: 'local-user',
   })
-  const failed = await waitForRunStatus(restartedLedger, pending.runId, 'failed')
+  const completed = await waitForTerminalRun(restartedLedger, pending.runId)
 
-  assert.deepEqual(invokedKinds, ['codex'])
-  assert.equal(failed.reason, 'LOCAL_RUN_ORCHESTRATION_RESUME_UNAVAILABLE')
-  assert.equal(failed.continuation.state, 'failed')
+  assert.deepEqual(
+    { status: completed.status, reason: completed.reason },
+    { status: 'completed', reason: '' },
+  )
+  assert.deepEqual(invokedKinds, ['codex', 'codex', 'hermes'])
+  assert.equal(completed.continuation.state, 'completed')
+  assert.deepEqual(completed.orchestration.pendingKinds, [])
+  assert.deepEqual(completed.orchestration.successfulKinds.sort(), ['codex', 'hermes'])
   assert.equal(restarted.snapshot().messages.some(message => (
-    message.role === 'agent' && message.agentKind === 'hermes'
-  )), false)
+    message.role === 'agent'
+      && message.agentKind === 'hermes'
+      && message.content === 'Hermes completed the remaining slot'
+  )), true)
+  const sequences = completed.agentRuns.flatMap(run => run.events.map(event => event.seq))
+  assert.deepEqual(sequences, [...sequences].sort((left, right) => left - right))
+  assert.equal(new Set(sequences).size, sequences.length)
+})
+
+test('restart resumes a middle Agent Gate without rerunning completed manual slots', async (t) => {
+  const { directory, options } = fixture()
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }))
+  const ledgerPath = path.join(directory, 'run-ledger.json')
+  const ledger = new RunLedger({ storagePath: ledgerPath })
+  const invokedKinds = []
+  options.runLedger = ledger
+  options.runAgent = async (agent, _prompt, _workdir, runOptions) => {
+    invokedKinds.push(agent.kind)
+    if (agent.kind === 'codex') {
+      return { text: 'Codex completed before the Gate', sessionRef: 'codex-first-session' }
+    }
+    if (agent.kind === 'workbuddy') {
+      return { text: 'WorkBuddy completed after the Gate', sessionRef: 'workbuddy-last-session' }
+    }
+    await runOptions.onSessionRef('kimi-middle-session', { transport: 'acp' })
+    const decision = await runOptions.onPermissionRequest({
+      options: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Reject once', kind: 'reject_once' },
+      ],
+      operation: { kind: 'write', path: 'middle-slot.txt' },
+    }, { signal: runOptions.signal })
+    return { text: `Kimi resumed:${decision.optionId}`, sessionRef: 'kimi-middle-session' }
+  }
+  const workspace = new LocalWorkspace(options)
+  await workspace.refreshAgents()
+  const group = workspace.createGroup({
+    name: 'Middle Gate recovery',
+    agentKinds: ['codex', 'kimi', 'workbuddy'],
+    workdir: directory,
+    allowWrite: true,
+  })
+  const gatePromise = pendingGate(workspace)
+  const send = workspace.sendMessage({
+    groupId: group.id,
+    text: 'Resume only the middle and remaining slots',
+    targetKinds: ['codex', 'kimi', 'workbuddy'],
+  })
+  const pending = await gatePromise
+  await workspace.stopAll()
+  await send
+
+  const restartedLedger = new RunLedger({ storagePath: ledgerPath })
+  assert.deepEqual(restartedLedger.get(pending.runId).orchestration.successfulKinds, ['codex'])
+  const restarted = new LocalWorkspace({ ...options, runLedger: restartedLedger })
+  await restarted.refreshAgents()
+  restarted.decideHumanGate(pending.gateId, {
+    status: 'approved', optionId: 'allow-once', actorId: 'local-user',
+  })
+  const terminal = await waitForTerminalRun(restartedLedger, pending.runId)
+
+  assert.deepEqual(
+    { status: terminal.status, reason: terminal.reason },
+    { status: 'completed', reason: '' },
+  )
+  assert.deepEqual(invokedKinds, ['codex', 'kimi', 'kimi', 'workbuddy'])
+  assert.deepEqual(terminal.orchestration.successfulKinds.sort(), ['codex', 'kimi', 'workbuddy'])
+  assert.equal(restarted.snapshot().messages.filter(message => (
+    message.role === 'agent' && message.agentKind === 'codex'
+  )).length, 1)
+})
+
+test('restart resumes the first automatic Agent slot and completes the round', async (t) => {
+  await verifyAutomaticGateRecovery(t, 0)
+})
+
+test('restart resumes the middle automatic Agent slot without rerunning earlier Agents', async (t) => {
+  await verifyAutomaticGateRecovery(t, 1)
+})
+
+test('restart resumes the final automatic Agent slot exactly once', async (t) => {
+  await verifyAutomaticGateRecovery(t, 2)
 })
 
 test('a failed Gate resume checkpoint restores live continuation state for retry', async (t) => {

--- a/desktop/test/local-workspace-state.test.cjs
+++ b/desktop/test/local-workspace-state.test.cjs
@@ -1,0 +1,44 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { loadWorkspaceState } = require('../src/local-workspace-state.cjs')
+
+function fixture(t) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'meldwork-workspace-state-'))
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }))
+  return path.join(directory, 'workspace.json')
+}
+
+test('distinguishes missing, corrupt, unreadable, unsupported, and valid workspace state', (t) => {
+  const storagePath = fixture(t)
+
+  assert.deepEqual(loadWorkspaceState(storagePath), {
+    state: {
+      version: 3, groups: [], messages: [], sessions: {}, sessionMeta: {},
+      agentPreferences: {}, agentRuntime: {},
+    },
+    status: 'missing',
+    trusted: true,
+    diagnostic: '',
+  })
+
+  fs.writeFileSync(storagePath, '{invalid json')
+  assert.equal(loadWorkspaceState(storagePath).status, 'corrupt')
+  assert.equal(loadWorkspaceState(storagePath).diagnostic, 'LOCAL_WORKSPACE_STATE_CORRUPT')
+
+  fs.writeFileSync(storagePath, JSON.stringify({ version: 99, groups: [], messages: [], sessions: {} }))
+  assert.equal(loadWorkspaceState(storagePath).status, 'unsupported')
+  assert.equal(loadWorkspaceState(storagePath).diagnostic, 'LOCAL_WORKSPACE_STATE_UNSUPPORTED')
+
+  fs.rmSync(storagePath)
+  fs.mkdirSync(storagePath)
+  assert.equal(loadWorkspaceState(storagePath).status, 'unreadable')
+  assert.equal(loadWorkspaceState(storagePath).diagnostic, 'LOCAL_WORKSPACE_STATE_UNREADABLE')
+
+  fs.rmSync(storagePath, { recursive: true })
+  fs.writeFileSync(storagePath, JSON.stringify({ version: 3, groups: [], messages: [], sessions: {} }))
+  assert.equal(loadWorkspaceState(storagePath).status, 'ready')
+  assert.equal(loadWorkspaceState(storagePath).trusted, true)
+})

--- a/desktop/test/local-workspace.test.cjs
+++ b/desktop/test/local-workspace.test.cjs
@@ -220,6 +220,7 @@ test('Custom Agent kinds keep their dynamic label across execution and reload', 
   await workspace.sendMessage({ groupId: group.id, text: 'Review this change', targetKinds: [kind] })
 
   assert.match(calls[0].prompt, /as Repository Reviewer\./)
+  assert.equal(calls[0].runOptions.sandbox, 'read-only')
   const reply = workspace.snapshot().messages.find(message => message.role === 'agent')
   assert.equal(reply.agentKind, kind)
   assert.equal(reply.senderName, 'Repository Reviewer')
@@ -228,6 +229,20 @@ test('Custom Agent kinds keep their dynamic label across execution and reload', 
   assert.equal(reloaded.snapshot().groups[0].directAgentKind, kind)
   assert.equal(reloaded.snapshot().messages.find(message => message.role === 'agent').senderName,
     'Repository Reviewer')
+
+  await reloaded.refreshAgents()
+  const writeGroup = reloaded.createGroup({
+    name: 'Writable review',
+    agentKinds: [kind],
+    allowWrite: true,
+    workdir: directory,
+  })
+  await reloaded.sendMessage({
+    groupId: writeGroup.id,
+    text: 'Apply the approved change',
+    targetKinds: [kind],
+  })
+  assert.equal(calls.at(-1).runOptions.sandbox, 'workspace-write')
 })
 
 test('shared Provider readiness skips slow native probes while a profile is active', async (t) => {

--- a/desktop/test/main-security.test.cjs
+++ b/desktop/test/main-security.test.cjs
@@ -435,6 +435,7 @@ test('Custom Agent IPC keeps executable paths private and refreshes the local ca
     'Review this change',
     '/tmp/project',
     {
+      sandbox: 'read-only',
       signal,
       attachments: ['/tmp/project/input.txt'],
       onProgress: () => {},
@@ -450,6 +451,7 @@ test('Custom Agent IPC keeps executable paths private and refreshes the local ca
   assert.equal(runPrompt, 'Review this change')
   assert.equal(runWorkdir, '/tmp/project')
   assert.equal(runOptions.signal, signal)
+  assert.equal(runOptions.sandbox, 'read-only')
   assert.deepEqual(runOptions.attachments, ['/tmp/project/input.txt'])
   assert.equal(runOptions.onOutboundPayload, onOutboundPayload)
   assert.equal(harness.runAgentCalls.length, 0)

--- a/desktop/test/run-harness.test.cjs
+++ b/desktop/test/run-harness.test.cjs
@@ -410,6 +410,23 @@ test('tracks answer delta sequences even though deltas stay outside the event le
   assert.equal(run.output, 'streamed')
 })
 
+test('hydrates the durable event cursor so post-restart sequences stay monotonic', () => {
+  const harness = fixture()
+  harness.beginAgent('codex', 1)
+  harness.ingest('codex', 1, { type: 'answer_delta', delta: 'first' })
+  const finalDelta = harness.ingest('codex', 1, { type: 'answer_delta', delta: 'second' })
+  const persisted = harness.snapshot()
+
+  assert.equal(persisted[0].eventCursor, finalDelta.seq)
+  assert.equal(Math.max(...persisted[0].events.map(event => event.seq)) < finalDelta.seq, true)
+
+  const restarted = fixture({ agentRuns: persisted })
+  const next = restarted.beginAgent('hermes', 1)
+
+  assert.equal(next.seq, finalDelta.seq + 1)
+  assert.equal(restarted.snapshot()[0].output, 'firstsecond')
+})
+
 test('finishes with the authoritative answer and persists only a compact capsule', () => {
   const harness = fixture()
   harness.beginAgent('hermes', 1, ['message-a', 'message-b'])


### PR DESCRIPTION
## Summary

- fail closed for legacy Custom Agents unless workspace write access is explicitly trusted
- quarantine missing, corrupt, unreadable, or unsupported workspace state without destructive Ledger reconciliation
- persist versioned manual and automatic orchestration cursors across Human Gates
- resume the exact pending Agent Session, continue remaining slots and later rounds, and preserve monotonic Harness event sequences

## Stability properties

- read-only Custom Agents cannot spawn through the legacy path
- untrusted workspace state stays read-only across repeated restarts
- completed Agent slots are not replayed during Gate recovery
- automatic first, middle, and final slots resume in order
- persisted traces remain visible and event cursors remain monotonic after restart
- legacy continuations without a trusted cursor continue to fail closed

## Verification

- `npm --prefix desktop test`: 890 passed
- `npm --prefix frontend test`: 249 passed
- `npm --prefix frontend run build`: passed
- `npm --prefix frontend run build:desktop`: passed
- `npm --prefix desktop run pack`: passed
- packaged `Meldwork.app` launched with an isolated profile; renderer ready, app root mounted, screenshot nonblank, and runtime exception count was 0

The local package is unsigned because this machine has no valid Developer ID identity.

Closes #15
Closes #16
Closes #17
