### PR TITLE
P1 security: Enforce Connector runtime contracts

### DIFF
--- a/desktop/src/agent-connector-local.cjs
+++ b/desktop/src/agent-connector-local.cjs
@@ -424,7 +424,7 @@ class LocalAgentConnectors {
       image: snapshot.capabilities.inputTypes.includes('image') ? 4 : 0,
       audio: snapshot.capabilities.inputTypes.includes('audio') ? 4 : 0,
       video: snapshot.capabilities.inputTypes.includes('video') ? 4 : 0,
-      file: 4,
+      file: snapshot.capabilities.inputTypes.includes('file') ? 4 : 0,
     }
   }
 
@@ -462,6 +462,7 @@ class LocalAgentConnectors {
         operationId: input.operationId,
         idempotencyKey: input.idempotencyKey,
         connectorResume: input.resume,
+        ...(input.credentialRefId ? { connectorCredentialIsolation: true } : {}),
         ...(Object.keys(credentialEnv).length ? { env: credentialEnv } : {}),
       })
       const outcome = String(result?.outcome || 'completed')

--- a/desktop/src/agent-connector-registry.cjs
+++ b/desktop/src/agent-connector-registry.cjs
@@ -347,6 +347,17 @@ class AgentConnectorRegistry {
       transport: deepClone(manifest.transport),
       credentialRef: instance.credentialRef,
       provenance: this.runProvenance(instanceId),
+      runtimeProvenance: {
+        connectorId: manifest.connectorId,
+        connectorVersion: manifest.connectorVersion,
+        manifestId: manifest.manifestId,
+        manifestSchemaVersion: manifest.schemaVersion,
+        instanceId: instance.instanceId,
+        recipeId: manifest.invocation.recipeId,
+        upstreamId: manifest.upstream.id,
+        upstreamVersion: instance.upstreamVersion,
+        credentialRefId: instance.credentialRef,
+      },
     })
   }
 }

--- a/desktop/src/agent-connector-runtime.cjs
+++ b/desktop/src/agent-connector-runtime.cjs
@@ -11,6 +11,8 @@ const PUBLIC_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$/
 const SHA256 = /^[a-f0-9]{64}$/
 const MAX_PROMPT_BYTES = 4 * 1024 * 1024
 const MAX_INPUT_RESPONSE_BYTES = 128 * 1024
+const MAX_ATTACHMENTS = 16
+const OUTBOUND_TRANSPORTS = new Set(['http', 'a2a'])
 
 function runtimeError(code) {
   const error = new Error(code)
@@ -24,6 +26,88 @@ function fail(code) {
 
 function clone(value) {
   return JSON.parse(canonicalJson(value))
+}
+
+function attachmentInputType(attachment) {
+  if (typeof attachment === 'string') return attachment ? 'image' : ''
+  if (!attachment || typeof attachment !== 'object' || Array.isArray(attachment)) return ''
+  const declared = String(attachment.inputType || attachment.type || '')
+  if (['image', 'audio', 'video', 'file', 'structured-data'].includes(declared)) {
+    return declared
+  }
+  const mimeType = String(attachment.mimeType || attachment.mediaType || '').toLowerCase()
+  if (mimeType.startsWith('image/')) return 'image'
+  if (mimeType.startsWith('audio/')) return 'audio'
+  if (mimeType.startsWith('video/')) return 'video'
+  return mimeType ? 'file' : ''
+}
+
+function validatedAttachments(value, capabilities) {
+  if (value == null) return []
+  if (!Array.isArray(value) || value.length > MAX_ATTACHMENTS) {
+    fail('AGENT_CONNECTOR_ATTACHMENTS_INVALID')
+  }
+  const attachments = [...value]
+  for (const attachment of attachments) {
+    const inputType = attachmentInputType(attachment)
+    if (!inputType) fail('AGENT_CONNECTOR_ATTACHMENTS_INVALID')
+    if (!capabilities.inputTypes.includes(inputType)) {
+      fail('AGENT_CONNECTOR_ATTACHMENT_UNSUPPORTED')
+    }
+  }
+  return attachments
+}
+
+function outboundOrigin(value) {
+  try {
+    const parsed = new URL(String(value || ''))
+    if (parsed.protocol !== 'https:' || parsed.username || parsed.password) return ''
+    return parsed.origin
+  } catch {
+    return ''
+  }
+}
+
+function assertOutboundDestination(connector, value) {
+  const destinations = connector.capabilities.outboundDestinations
+  const destination = String(value || '')
+  if (!destination) {
+    if (destinations.length || OUTBOUND_TRANSPORTS.has(connector.transport.type)) {
+      fail('AGENT_CONNECTOR_OUTBOUND_DESTINATION_REQUIRED')
+    }
+    return ''
+  }
+  const origin = outboundOrigin(destination)
+  if (!origin || !destinations.includes(origin)) {
+    fail('AGENT_CONNECTOR_OUTBOUND_DESTINATION_UNSUPPORTED')
+  }
+  return origin
+}
+
+function assertEventCapabilities(connector, input) {
+  const type = String(input?.type || '')
+  if (!connector.capabilities.eventTypes.includes(type)) {
+    fail('AGENT_CONNECTOR_EVENT_UNDECLARED')
+  }
+  if (type === 'Cancelled' && !connector.capabilities.session.cancel) {
+    fail('AGENT_CONNECTOR_CANCEL_UNSUPPORTED')
+  }
+  if (type === 'Usage') {
+    for (const field of Object.keys(input?.usage || {})) {
+      if (connector.capabilities.usage[field] !== true) {
+        fail('AGENT_CONNECTOR_USAGE_UNDECLARED')
+      }
+    }
+  }
+}
+
+function assertResultCapabilities(connector, result) {
+  if (String(result?.sessionRef || '') && !connector.capabilities.session.supported) {
+    fail('AGENT_CONNECTOR_SESSION_UNSUPPORTED')
+  }
+  if (result?.outcome === 'cancelled' && !connector.capabilities.session.cancel) {
+    fail('AGENT_CONNECTOR_CANCEL_UNSUPPORTED')
+  }
 }
 
 function normalizeResume(input) {
@@ -260,7 +344,24 @@ class AgentConnectorRuntime {
     if (!connector.capabilities.inputTypes.includes('text')) {
       fail('AGENT_CONNECTOR_INPUT_UNSUPPORTED')
     }
+    const sessionRef = String(options.sessionRef || '')
+    if (sessionRef && !connector.capabilities.session.supported) {
+      fail('AGENT_CONNECTOR_SESSION_UNSUPPORTED')
+    }
+    if (sessionRef && !connector.capabilities.session.resume) {
+      fail('AGENT_CONNECTOR_RESUME_UNSUPPORTED')
+    }
+    const resume = normalizeResume(options.connectorResume)
+    if (resume && (!connector.capabilities.session.supported
+        || !connector.capabilities.session.resume)) {
+      fail('AGENT_CONNECTOR_RESUME_UNSUPPORTED')
+    }
+    if (options.signal?.aborted && !connector.capabilities.session.cancel) {
+      fail('AGENT_CONNECTOR_CANCEL_UNSUPPORTED')
+    }
+    const attachments = validatedAttachments(options.attachments, connector.capabilities)
     const emit = (input) => {
+      assertEventCapabilities(connector, input)
       const event = parseConnectorRunEvent(input, provenance)
       const duplicate = state.events.find(existing => existing.eventId === event.eventId)
       if (duplicate && canonicalJson(duplicate) === canonicalJson(event)) return event
@@ -270,7 +371,10 @@ class AgentConnectorRuntime {
       try { options.onEvent?.(harnessEvent(event)) } catch { /* Renderer events are best effort. */ }
       return event
     }
-    const resume = normalizeResume(options.connectorResume)
+    const onOutboundPayload = (outbound = {}) => {
+      assertOutboundDestination(connector, outbound.destination)
+      return options.onOutboundPayload?.(outbound)
+    }
 
     const result = await handler(Object.freeze({
       agent: Object.freeze({
@@ -279,6 +383,7 @@ class AgentConnectorRuntime {
       }),
       connector,
       credentialRefId: execution.credentialRef,
+      provenance: execution.runtimeProvenance,
       runId,
       agentRunId,
       operationId,
@@ -286,13 +391,16 @@ class AgentConnectorRuntime {
       prompt: promptText,
       workdir: resolvedWorkdir,
       permissionMode,
-      sessionRef: String(options.sessionRef || ''),
-      attachments: Array.isArray(options.attachments) ? [...options.attachments] : [],
-      signal: options.signal,
+      sessionRef,
+      attachments,
+      signal: connector.capabilities.session.cancel ? options.signal : undefined,
       emit,
       onProgress: options.onProgress,
       onRuntimeEvent: options.onEvent,
-      onOutboundPayload: options.onOutboundPayload,
+      onOutboundPayload,
+      assertOutboundDestination: destination => assertOutboundDestination(
+        connector, destination,
+      ),
       onPermissionRequest: options.onPermissionRequest,
       resume,
     }))
@@ -300,6 +408,7 @@ class AgentConnectorRuntime {
     if (!result || typeof result !== 'object' || Array.isArray(result)) {
       fail('AGENT_CONNECTOR_RESULT_INVALID')
     }
+    assertResultCapabilities(connector, result)
     if (result.outcome != null && result.outcome !== state.status) {
       fail('AGENT_CONNECTOR_RESULT_MISMATCH')
     }

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -311,22 +311,30 @@ async function validateKnowledgeBaseSelections(targetKinds, selections) {
 }
 
 async function runCoreAgent(agent, prompt, workdir, options = {}) {
+  const connectorCredentialIsolation = options.connectorCredentialIsolation === true
+  const runOptions = { ...options }
+  delete runOptions.connectorCredentialIsolation
   const status = providerStore.status(agent.kind)
-  const nativeRuntime = agent.kind === 'openclaw' && !status.configured
+  const nativeRuntime = !connectorCredentialIsolation
+    && agent.kind === 'openclaw' && !status.configured
     ? await resolveNativeOpenClawRuntime({ executable: agent.executable })
     : null
-  const injected = providerOptions(agent.kind, {
-    ...options,
-    workdir,
-    storageRoot: app.getPath('userData'),
-    nativeRuntime,
-  })
-  const nativeEnv = agent.kind === 'openclaw'
+  const injected = connectorCredentialIsolation
+    ? {}
+    : providerOptions(agent.kind, {
+        ...runOptions,
+        workdir,
+        storageRoot: app.getPath('userData'),
+        nativeRuntime,
+      })
+  const nativeEnv = connectorCredentialIsolation || agent.kind === 'openclaw'
     ? {}
     : nativeCredentialEnvironment(agent.kind)
-  const callerEnv = agent.kind === 'openclaw' ? {} : options.env
+  const callerEnv = connectorCredentialIsolation || agent.kind !== 'openclaw'
+    ? runOptions.env
+    : {}
   return runAgent(agent, prompt, workdir, {
-    ...options,
+    ...runOptions,
     ...injected,
     env: { ...nativeEnv, ...callerEnv, ...injected.env },
   })
@@ -337,7 +345,7 @@ function localAttachmentSupport(kind) {
     return { image: 4, audio: 4, video: 4, file: 4 }
   }
   const connectorSupport = agentConnectors?.attachmentSupport(kind)
-  if (connectorSupport) return { ...connectorSupport, file: 4 }
+  if (connectorSupport) return connectorSupport
   return {
     image: imageAttachmentLimit(kind),
     file: kind === 'opencodereview' ? 0 : 4,

--- a/desktop/src/outbound-payload.cjs
+++ b/desktop/src/outbound-payload.cjs
@@ -38,12 +38,15 @@ function cliWirePayload(command, args, cwd, stdin) {
   }
 }
 
-function createLegacyOutboundPayload({ prompt, command, args, cwd, stdin, promptMode }) {
+function createLegacyOutboundPayload({
+  prompt, command, args, cwd, stdin, promptMode, destination = '',
+}) {
   return payloadWithFingerprint({
     prompt,
     transport: 'legacy',
     serialization: 'cli-argv-stdin-v1',
     promptMode,
+    ...(destination ? { destination } : {}),
   }, cliWirePayload(command, args, cwd, stdin))
 }
 

--- a/desktop/test/agent-connector-local.test.cjs
+++ b/desktop/test/agent-connector-local.test.cjs
@@ -226,6 +226,7 @@ test('restores multiple credential-bearing accounts and drops invalid references
     runId: 'run-3', agentRunId: 'agent-run-3', sandbox: 'read-only',
   })
   assert.equal(calls.at(-1)[3].env.OPENAI_API_KEY, 'connector-secret-a')
+  assert.equal(calls.at(-1)[3].connectorCredentialIsolation, true)
   assert.equal(Object.hasOwn(calls.at(-1)[3], 'credentialRefId'), false)
 
   const records = createInstanceStore().listRecords()

--- a/desktop/test/agent-connector-registry.test.cjs
+++ b/desktop/test/agent-connector-registry.test.cjs
@@ -136,6 +136,18 @@ test('supports multiple instances and keeps CredentialRefs out of Run provenance
   assert.equal(execution.recipeId, 'external.review-agent.run')
   assert.equal(execution.credentialRef, 'credential-ref:review-account-a')
   assert.deepEqual(execution.provenance, provenance)
+  assert.deepEqual(execution.runtimeProvenance, {
+    connectorId: manifest.connectorId,
+    connectorVersion: manifest.connectorVersion,
+    manifestId: manifest.manifestId,
+    manifestSchemaVersion: manifest.schemaVersion,
+    instanceId: first.instanceId,
+    recipeId: manifest.invocation.recipeId,
+    upstreamId: manifest.upstream.id,
+    upstreamVersion: first.upstreamVersion,
+    credentialRefId: 'credential-ref:review-account-a',
+  })
+  assert.equal(Object.isFrozen(execution.runtimeProvenance), true)
   assert.throws(
     () => parseConnectorRunSnapshot({ ...snapshot, connectorVersion: 'not-semver' }),
     { message: 'AGENT_CONNECTOR_RUN_SNAPSHOT_INVALID' },

--- a/desktop/test/agent-connector-runtime.test.cjs
+++ b/desktop/test/agent-connector-runtime.test.cjs
@@ -70,13 +70,30 @@ function runtimeFixture(handler, overrides = {}) {
 test('discovers and runs an approved external Connector with trusted durable provenance', async () => {
   const states = []
   const uiEvents = []
+  const outbound = []
   const { manifest, runtime } = runtimeFixture(async (input) => {
     assert.equal(input.credentialRefId, 'credential-ref:review-account-a')
     assert.equal(input.connector.connectorVersion, '1.0.0')
     assert.equal(input.connector.upstreamVersion, '3.2.0')
     assert.equal(input.permissionMode, 'read-only')
+    assert.deepEqual(input.provenance, {
+      connectorId: manifest.connectorId,
+      connectorVersion: manifest.connectorVersion,
+      manifestId: manifest.manifestId,
+      manifestSchemaVersion: manifest.schemaVersion,
+      instanceId: 'custom-aaaaaaaaaaaaaaaa',
+      recipeId: manifest.invocation.recipeId,
+      upstreamId: manifest.upstream.id,
+      upstreamVersion: '3.2.0',
+      credentialRefId: 'credential-ref:review-account-a',
+    })
     assert.equal(Object.hasOwn(input, 'executable'), false)
     assert.equal(Object.isFrozen(input.connector), true)
+    assert.equal(input.assertOutboundDestination('https://review.example.com/v1'), 'https://review.example.com')
+    await input.onOutboundPayload({
+      destination: 'https://review.example.com/v1',
+      transport: 'http',
+    })
     input.emit({
       eventId: 'event-3', cursor: 'cursor-3', sequence: 3,
       type: 'Completed', outcome: 'completed', summary: 'Review complete.',
@@ -89,7 +106,7 @@ test('discovers and runs an approved external Connector with trusted durable pro
     input.emit(source)
     input.emit({
       eventId: 'event-2', cursor: 'cursor-2', sequence: 2,
-      type: 'Progress', rawOutput: 'Bearer connector-secret',
+      type: 'Usage', mode: 'delta', usage: { inputTokens: 12 },
     })
     input.emit(source)
     return { text: 'External review result', sessionRef: 'review-session' }
@@ -106,19 +123,141 @@ test('discovers and runs an approved external Connector with trusted durable pro
     sandbox: 'read-only',
     onConnectorState: context => states.push(context),
     onEvent: event => uiEvents.push(event),
+    onOutboundPayload: payload => outbound.push(payload),
   })
   assert.equal(result.text, 'External review result')
   assert.equal(result.outcome, 'completed')
   assert.equal(result.connector.manifestId, manifest.manifestId)
   assert.deepEqual(result.connectorEventState.events.map(event => event.type), [
-    'SourceUsed', 'Unknown', 'Completed',
+    'SourceUsed', 'Usage', 'Completed',
   ])
-  assert.equal(result.connectorEventState.events[1].originalType, 'Progress')
-  assert.doesNotMatch(JSON.stringify(result.connectorEventState), /connector-secret/)
+  assert.equal(result.connectorEventState.usage.inputTokens, 12)
   assert.equal(states.length, 4)
   assert.deepEqual(states.at(-1).connectorEventState, result.connectorEventState)
   assert.equal(uiEvents.length, 3)
   assert.equal(uiEvents.every(event => !Object.hasOwn(event, 'rawOutput')), true)
+  assert.deepEqual(outbound, [{
+    destination: 'https://review.example.com/v1',
+    transport: 'http',
+  }])
+})
+
+test('rejects every undeclared Connector capability before it crosses the recipe boundary', async () => {
+  const terminalTypes = ['Completed', 'Failed', 'Cancelled']
+  const hashes = {
+    requestHash: 'a'.repeat(64),
+    sessionRefHash: 'b'.repeat(64),
+    sessionProvenanceHash: 'c'.repeat(64),
+  }
+
+  const attachments = runtimeFixture(async () => {
+    assert.fail('attachment contract must reject before recipe execution')
+  }, { inputTypes: ['text'] }).runtime
+  await assert.rejects(attachments.run(
+    attachments.detectAgents()[0], 'Review', '/tmp/workspace', {
+      runId: 'run-attachment', agentRunId: 'agent-run-attachment', sandbox: 'read-only',
+      attachments: ['/tmp/undeclared.png'],
+    },
+  ), { message: 'AGENT_CONNECTOR_ATTACHMENT_UNSUPPORTED' })
+
+  const noSessions = runtimeFixture(async () => {
+    assert.fail('session contract must reject before recipe execution')
+  }, { session: { supported: false, resume: false, cancel: false, checkpoint: false } }).runtime
+  await assert.rejects(noSessions.run(
+    noSessions.detectAgents()[0], 'Review', '/tmp/workspace', {
+      runId: 'run-session', agentRunId: 'agent-run-session', sandbox: 'read-only',
+      sessionRef: 'existing-session',
+    },
+  ), { message: 'AGENT_CONNECTOR_SESSION_UNSUPPORTED' })
+
+  const noResume = runtimeFixture(async () => {
+    assert.fail('resume contract must reject before recipe execution')
+  }, { session: { supported: true, resume: false, cancel: true, checkpoint: false } }).runtime
+  await assert.rejects(noResume.run(
+    noResume.detectAgents()[0], 'Review', '/tmp/workspace', {
+      runId: 'run-resume', agentRunId: 'agent-run-resume', sandbox: 'read-only',
+      connectorResume: {
+        type: 'input', requestId: 'request-input', response: 'continue', ...hashes,
+      },
+    },
+  ), { message: 'AGENT_CONNECTOR_RESUME_UNSUPPORTED' })
+
+  const noCancel = runtimeFixture(async (input) => {
+    assert.equal(input.signal, undefined)
+    input.emit({
+      eventId: 'cancelled', cursor: 'cancelled', sequence: 1,
+      type: 'Cancelled', reason: 'user',
+    })
+  }, { session: { supported: true, resume: true, cancel: false, checkpoint: false } }).runtime
+  await assert.rejects(noCancel.run(
+    noCancel.detectAgents()[0], 'Review', '/tmp/workspace', {
+      runId: 'run-cancel', agentRunId: 'agent-run-cancel', sandbox: 'read-only',
+      signal: new AbortController().signal,
+    },
+  ), { message: 'AGENT_CONNECTOR_CANCEL_UNSUPPORTED' })
+
+  const undeclaredEvent = runtimeFixture(async (input) => {
+    input.emit({
+      eventId: 'source', cursor: 'source', sequence: 1,
+      type: 'SourceUsed', sourceId: 'source-1', sourceType: 'workspace-file',
+      contentHash: 'd'.repeat(64),
+    })
+  }, { eventTypes: terminalTypes }).runtime
+  await assert.rejects(undeclaredEvent.run(
+    undeclaredEvent.detectAgents()[0], 'Review', '/tmp/workspace', {
+      runId: 'run-event', agentRunId: 'agent-run-event', sandbox: 'read-only',
+    },
+  ), { message: 'AGENT_CONNECTOR_EVENT_UNDECLARED' })
+
+  const undeclaredUsage = runtimeFixture(async (input) => {
+    input.emit({
+      eventId: 'usage', cursor: 'usage', sequence: 1,
+      type: 'Usage', mode: 'delta', usage: { inputTokens: 1 },
+    })
+  }, {
+    eventTypes: [...terminalTypes, 'Usage'],
+    usage: {
+      inputTokens: false, outputTokens: false, costMicros: false,
+      toolCalls: false, outboundBytes: false, elapsedMs: false,
+    },
+  }).runtime
+  await assert.rejects(undeclaredUsage.run(
+    undeclaredUsage.detectAgents()[0], 'Review', '/tmp/workspace', {
+      runId: 'run-usage', agentRunId: 'agent-run-usage', sandbox: 'read-only',
+    },
+  ), { message: 'AGENT_CONNECTOR_USAGE_UNDECLARED' })
+
+  const undeclaredDestination = runtimeFixture(async (input) => {
+    input.onOutboundPayload({ destination: 'https://untrusted.example.com/v1' })
+  }).runtime
+  await assert.rejects(undeclaredDestination.run(
+    undeclaredDestination.detectAgents()[0], 'Review', '/tmp/workspace', {
+      runId: 'run-destination', agentRunId: 'agent-run-destination', sandbox: 'read-only',
+    },
+  ), { message: 'AGENT_CONNECTOR_OUTBOUND_DESTINATION_UNSUPPORTED' })
+
+  const missingDestination = runtimeFixture(async (input) => {
+    input.onOutboundPayload({ transport: 'http' })
+  }).runtime
+  await assert.rejects(missingDestination.run(
+    missingDestination.detectAgents()[0], 'Review', '/tmp/workspace', {
+      runId: 'run-missing-destination', agentRunId: 'agent-run-missing-destination',
+      sandbox: 'read-only',
+    },
+  ), { message: 'AGENT_CONNECTOR_OUTBOUND_DESTINATION_REQUIRED' })
+
+  const undeclaredSessionResult = runtimeFixture(async (input) => {
+    input.emit({
+      eventId: 'completed', cursor: 'completed', sequence: 1,
+      type: 'Completed', outcome: 'completed',
+    })
+    return { text: 'done', sessionRef: 'undeclared-session' }
+  }, { session: { supported: false, resume: false, cancel: false, checkpoint: false } }).runtime
+  await assert.rejects(undeclaredSessionResult.run(
+    undeclaredSessionResult.detectAgents()[0], 'Review', '/tmp/workspace', {
+      runId: 'run-session-result', agentRunId: 'agent-run-session-result', sandbox: 'read-only',
+    },
+  ), { message: 'AGENT_CONNECTOR_SESSION_UNSUPPORTED' })
 })
 
 test('fails closed when a recipe, permission mode, or terminal event is missing', async () => {

--- a/desktop/test/local-workspace-harness.test.cjs
+++ b/desktop/test/local-workspace-harness.test.cjs
@@ -218,6 +218,7 @@ test('external Connectors bypass the legacy runner and persist trusted provenanc
           cwd: input.workdir,
           stdin: input.prompt,
           promptMode: 'stdin',
+          destination: 'https://review.example.com/v1',
         }))
         input.emit({
           eventId: 'source-1', cursor: 'cursor-1', sequence: 1,

--- a/desktop/test/main-security.test.cjs
+++ b/desktop/test/main-security.test.cjs
@@ -309,6 +309,7 @@ test('Agent Connector IPC persists isolated accounts without returning Credentia
     serializeAgentConnectorManifest(SAMPLE_CREDENTIAL_AGENT_CONNECTOR_MANIFEST),
   )
   const options = {
+    providerConfigured: true,
     detectedAgents: [{
       kind: 'codex', name: 'Codex CLI', executable: '/private/bin/codex',
       version: 'codex-cli 0.147.0', compatibilityState: 'compatible',
@@ -346,6 +347,18 @@ test('Agent Connector IPC persists isolated accounts without returning Credentia
   )
   assert.doesNotMatch(JSON.stringify(result), /credential-ref|connector-main-secret/i)
   assert.equal(harness.runAgentCalls.at(-1)[3].env.OPENAI_API_KEY, 'connector-main-secret-a')
+  assert.equal(Object.hasOwn(harness.runAgentCalls.at(-1)[3].env, 'OPENAI_BASE_URL'), false)
+  assert.equal(Object.hasOwn(harness.runAgentCalls.at(-1)[3].env, 'OPENAI_MODEL'), false)
+  assert.equal(Object.hasOwn(harness.runAgentCalls.at(-1)[3], 'connectorCredentialIsolation'), false)
+
+  await workspace.input.connectorRuntime.run(
+    agents.find(agent => agent.kind === second.instanceId),
+    'Review with account B',
+    directory,
+    { runId: 'run-account-b', agentRunId: 'agent-run-account-b', sandbox: 'read-only' },
+  )
+  assert.equal(harness.runAgentCalls.at(-1)[3].env.OPENAI_API_KEY, 'connector-main-secret-b')
+  assert.notEqual(harness.runAgentCalls.at(-1)[3].env.OPENAI_API_KEY, 'provider-key')
 
   const instanceFile = fs.readFileSync(
     path.join(directory, 'agent-connectors', 'instances.json'),


### PR DESCRIPTION
## Summary

- isolate CredentialRef-backed Connector accounts from unrelated active Provider profiles through the final child-process environment
- enforce Manifest declarations for attachments, Session use and resume, cancellation, event types, Usage fields, permission modes, and input types
- require every reported external destination to match an exact declared HTTPS origin before outbound delivery is recorded
- retain exact main-process execution provenance for instance, Manifest schema/version, Recipe, upstream version, and CredentialRef while keeping CredentialRefs out of renderer-visible snapshots
- expose only declared attachment capabilities in the Agent catalog

## Stability and security impact

This is a fail-closed P1 security change stacked on #36. Connector-specific credentials now bypass global/native credential injection, internal isolation markers are removed before process launch, and existing built-in Agent Provider routing is unchanged.

## Verification

- focused Connector, provenance, Context Pack, and main-security tests: 75/75
- `npm --prefix desktop test`: 916/916
- `npm --prefix desktop run pack`
- isolated packaged `Meldwork.app` CDP smoke: app.asar `#/chat`, document complete, rendered root, 6 Agents ready, no Vite error overlay
- `git diff --check`

Addresses #26.

Stack dependency: #36.