### PR TITLE
P1: Align Agent readiness with invocation prerequisites

### DIFF
--- a/desktop/src/agent-compatibility.cjs
+++ b/desktop/src/agent-compatibility.cjs
@@ -1,4 +1,31 @@
 const VERSION_PATTERN = /\bv?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z][0-9A-Za-z.-]*))?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?\b/
+const ANSI_PATTERN = /\x1b\[[0-?]*[ -\/]*[@-~]/g
+const AGENT_VERSION_IDENTITIES = Object.freeze({
+  codex: [/\bcodex(?:-cli)?\b/i],
+  hermes: [/\bhermes(?:\s+agent)?\b/i],
+  openclaw: [/\bopenclaw\b/i],
+  workbuddy: [/\b(?:workbuddy|codebuddy)\b/i],
+  kimi: [/\bkimi(?:\s+code)?\b/i],
+  mimo: [/\bmimo(?:\s+code)?\b/i, /\bmimocode\b/i],
+  claude: [/\bclaude(?:\s+code)?\b/i],
+  gemini: [/\bgemini(?:\s+cli)?\b/i],
+  opencode: [/\bopencode\b/i, /\bopen\s+code\b/i],
+  qwen: [/\bqwen(?:\s+code)?\b/i],
+  opencodereview: [/\bopen[-\s]?code[-\s]?review\b/i],
+})
+const AGENT_EXECUTABLE_NAMES = Object.freeze({
+  codex: ['codex'],
+  hermes: ['hermes'],
+  openclaw: ['openclaw'],
+  workbuddy: ['codebuddy'],
+  kimi: ['kimi'],
+  mimo: ['mimo'],
+  claude: ['claude'],
+  gemini: ['gemini'],
+  opencode: ['opencode'],
+  qwen: ['qwen'],
+  opencodereview: ['ocr'],
+})
 
 const AGENT_COMPATIBILITY = Object.freeze({
   codex: profile('0.137.0', '0.146.0', [
@@ -99,6 +126,81 @@ function extractAgentVersion(value) {
   return `${match[1]}.${match[2]}.${match[3]}${match[4] ? `-${match[4]}` : ''}`
 }
 
+function normalizedVersionLines(outputs) {
+  return (Array.isArray(outputs) ? outputs : [outputs])
+    .flatMap(output => String(output || '').replace(ANSI_PATTERN, '').split(/\r?\n/))
+    .map(line => line.trim())
+    .filter(Boolean)
+}
+
+function uniqueVersionCandidate(lines) {
+  const candidates = lines
+    .map(line => ({ line, resolvedVersion: extractAgentVersion(line) }))
+    .filter(candidate => candidate.resolvedVersion)
+  const versions = [...new Set(candidates.map(candidate => candidate.resolvedVersion))]
+  return versions.length === 1
+    ? candidates.find(candidate => candidate.resolvedVersion === versions[0])
+    : null
+}
+
+function versionMatches(line) {
+  const pattern = new RegExp(VERSION_PATTERN.source, 'g')
+  return [...line.matchAll(pattern)].map((match) => ({
+    index: match.index,
+    end: match.index + match[0].length,
+    resolvedVersion: extractAgentVersion(match[0]),
+  }))
+}
+
+function identifiedVersionCandidate(kind, lines) {
+  const identities = AGENT_VERSION_IDENTITIES[kind] || []
+  const candidates = []
+  for (const line of lines) {
+    const identityMatches = identities.map(identity => identity.exec(line)).filter(Boolean)
+    const versions = versionMatches(line)
+    const weighted = []
+    for (const identity of identityMatches) {
+      const identityEnd = identity.index + identity[0].length
+      for (const version of versions) {
+        const distance = version.end <= identity.index
+          ? identity.index - version.end
+          : version.index >= identityEnd
+            ? version.index - identityEnd
+            : 0
+        weighted.push({ ...version, distance })
+      }
+    }
+    const closestDistance = Math.min(...weighted.map(candidate => candidate.distance))
+    const closestVersions = [...new Set(weighted
+      .filter(candidate => candidate.distance === closestDistance)
+      .map(candidate => candidate.resolvedVersion))]
+    if (closestVersions.length === 1) {
+      candidates.push({ line, resolvedVersion: closestVersions[0] })
+    }
+  }
+  const versions = [...new Set(candidates.map(candidate => candidate.resolvedVersion))]
+  return versions.length === 1
+    ? candidates.find(candidate => candidate.resolvedVersion === versions[0])
+    : null
+}
+
+function executableIdentifiesAgent(kind, executable) {
+  const basename = String(executable || '')
+    .split(/[\\/]/).at(-1)?.replace(/\.(?:bat|cmd|com|exe)$/i, '').toLowerCase()
+  return (AGENT_EXECUTABLE_NAMES[kind] || []).includes(basename)
+}
+
+function identifyAgentVersion(kind, outputs, options = {}) {
+  const lines = normalizedVersionLines(outputs)
+  const identified = identifiedVersionCandidate(kind, lines)
+  if (identified) return identified
+
+  if (!executableIdentifiesAgent(kind, options.executable)) return null
+  return uniqueVersionCandidate(lines.filter(line => (
+    new RegExp(`^v?${VERSION_PATTERN.source}$`, 'i').test(line)
+  )))
+}
+
 function compareReleaseVersions(left, right) {
   const parse = (value) => {
     const match = String(value || '').match(/^(\d+)\.(\d+)\.(\d+)$/)
@@ -123,8 +225,8 @@ function assessAgentVersion(kind, rawVersion) {
   if (!contract || !resolvedVersion) {
     return {
       ...base,
-      compatibilityState: 'incompatible',
-      incompatibilityReason: 'LOCAL_AGENT_VERSION_UNSUPPORTED',
+      compatibilityState: 'unknown',
+      incompatibilityReason: '',
     }
   }
   const supported = contract.exactVersion
@@ -155,4 +257,5 @@ module.exports = {
   assessAgentVersion,
   capabilityProbes,
   extractAgentVersion,
+  identifyAgentVersion,
 }

--- a/desktop/src/agent-installer.cjs
+++ b/desktop/src/agent-installer.cjs
@@ -37,15 +37,17 @@ function publicCompatibility(agent) {
   if (!agent) {
     return {
       resolvedVersion: '',
+      versionIdentified: false,
+      compatible: false,
       supportedVersionRange: '',
       compatibilityState: 'unknown',
       incompatibilityReason: '',
       incompatibilityProbe: '',
     }
   }
-  const compatibilityState = agent.compatibilityState === 'compatible'
-    ? 'compatible'
-    : 'incompatible'
+  const compatibilityState = ['compatible', 'incompatible'].includes(agent.compatibilityState)
+    ? agent.compatibilityState
+    : 'unknown'
   const resolvedVersion = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
     .test(String(agent.resolvedVersion || ''))
     ? agent.resolvedVersion
@@ -54,6 +56,10 @@ function publicCompatibility(agent) {
     .test(String(agent.supportedVersionRange || ''))
     ? agent.supportedVersionRange
     : ''
+  const versionIdentified = typeof agent.versionIdentified === 'boolean'
+    ? agent.versionIdentified
+    : Boolean(resolvedVersion)
+  const compatible = compatibilityState === 'compatible'
   const incompatibilityReason = compatibilityState === 'incompatible'
     ? (COMPATIBILITY_REASONS.has(agent.incompatibilityReason)
         ? agent.incompatibilityReason
@@ -65,6 +71,8 @@ function publicCompatibility(agent) {
     : ''
   return {
     resolvedVersion,
+    versionIdentified,
+    compatible,
     supportedVersionRange,
     compatibilityState,
     incompatibilityReason,

--- a/desktop/src/cli-discovery.cjs
+++ b/desktop/src/cli-discovery.cjs
@@ -6,7 +6,7 @@ const { promisify } = require('node:util')
 const {
   assessAgentVersion,
   capabilityProbes,
-  extractAgentVersion,
+  identifyAgentVersion,
 } = require('./agent-compatibility.cjs')
 
 const execFileAsync = promisify(execFile)
@@ -395,22 +395,20 @@ async function inspectAgentCandidate(kind, executable, options, childEnv) {
         windowsHide: true,
         env: childEnv,
       })
-      const lines = [result.stdout, result.stderr]
-        .flatMap(output => String(output || '').split(/\r?\n/))
-        .map(line => line.trim())
-        .filter(Boolean)
+      const identified = identifyAgentVersion(kind, [result.stdout, result.stderr], { executable })
       return {
         succeeded: true,
-        version: lines.find(line => extractAgentVersion(line)) || '',
+        version: identified?.line || '',
+        versionIdentified: Boolean(identified),
       }
     } catch { /* a broken shim is not a usable CLI */ }
-    return { succeeded: false, version: '' }
+    return { succeeded: false, version: '', versionIdentified: false }
   })()
 
-  const { succeeded: versionCommandSucceeded, version } = await versionTask
+  const { succeeded: versionCommandSucceeded, version, versionIdentified } = await versionTask
   if (!versionCommandSucceeded) return null
   const versionCompatibility = assessAgentVersion(kind, version)
-  if (versionCompatibility.compatibilityState !== 'compatible') {
+  if (versionIdentified && versionCompatibility.compatibilityState === 'incompatible') {
     return {
       kind,
       name: `${AGENT_PROFILES[kind].label} CLI`,
@@ -445,13 +443,15 @@ async function inspectAgentCandidate(kind, executable, options, childEnv) {
       })()
     : Promise.resolve(undefined)
   const [capabilityCompatibility, acpAvailable] = await Promise.all([capabilityTask, acpTask])
+  const compatibility = capabilityCompatibility.compatibilityState === 'incompatible'
+    ? { ...versionCompatibility, ...capabilityCompatibility }
+    : { ...versionCompatibility, incompatibilityProbe: '' }
   return {
     kind,
     name: `${AGENT_PROFILES[kind].label} CLI`,
     executable,
     version,
-    ...versionCompatibility,
-    ...capabilityCompatibility,
+    ...compatibility,
     ...(kind === 'hermes' ? { acpAvailable } : {}),
   }
 }

--- a/desktop/src/local-agent-readiness.cjs
+++ b/desktop/src/local-agent-readiness.cjs
@@ -234,14 +234,14 @@ function parseOpenClawStatus(output, options = {}) {
     }
     const requestedAgentDir = String(status?.agentDir || '').trim()
     if (!path.isAbsolute(requestedAgentDir)) {
-      return { credentialState: { state: 'ready', source: 'native-auth-status' } }
+      return { credentialState: { state: 'unknown', source: 'native-runtime-unavailable' } }
     }
     const resolvedHome = fs.realpathSync(path.resolve(options.home || os.homedir()))
     const nativeRoot = path.join(resolvedHome, '.openclaw')
     const nativeRootIdentity = openClawDirectoryIdentity(nativeRoot)
     const agentDir = fs.realpathSync(requestedAgentDir)
     if (!fs.statSync(agentDir).isDirectory() || !pathInside(nativeRoot, agentDir)) {
-      return { credentialState: { state: 'ready', source: 'native-auth-status' } }
+      return { credentialState: { state: 'unknown', source: 'native-runtime-unavailable' } }
     }
     const directoryIdentities = [nativeRootIdentity]
     let current = nativeRoot
@@ -260,6 +260,16 @@ function parseOpenClawStatus(output, options = {}) {
   } catch {
     return null
   }
+}
+
+function resolveOpenClawRuntimeStatus(status) {
+  if (!status?.runtime || status.credentialState?.state !== 'ready') return null
+  const parts = openClawModelParts(status.runtime.model)
+  if (!parts) return null
+  return parseOpenClawModelsFile(
+    readOpenClawModelsFile(status.runtime),
+    status.runtime.model,
+  )
 }
 
 function openClawModelParts(modelRef) {
@@ -402,16 +412,8 @@ async function queryOpenClawStatus(options = {}) {
 
 async function resolveNativeOpenClawRuntime(options = {}) {
   const status = await queryOpenClawStatus(options)
-  if (!status?.runtime || status.credentialState?.state !== 'ready') {
-    throw new Error('OPENCLAW_NATIVE_RUNTIME_UNAVAILABLE')
-  }
-  const parts = openClawModelParts(status.runtime.model)
-  if (!parts) throw new Error('OPENCLAW_NATIVE_RUNTIME_UNAVAILABLE')
   try {
-    const runtime = parseOpenClawModelsFile(
-      readOpenClawModelsFile(status.runtime),
-      status.runtime.model,
-    )
+    const runtime = resolveOpenClawRuntimeStatus(status)
     if (runtime) return runtime
   } catch { /* fail closed below */ }
   throw new Error('OPENCLAW_NATIVE_RUNTIME_UNAVAILABLE')
@@ -442,7 +444,15 @@ async function resolveNativeCredentialState(kind, options = {}) {
   const current = nativeCredentialState(kind, options)
   if (kind === 'openclaw') {
     const status = await queryOpenClawStatus(options)
-    return status?.credentialState || current
+    if (status?.credentialState?.state === 'missing') return status.credentialState
+    try {
+      if (resolveOpenClawRuntimeStatus(status)) {
+        return { state: 'ready', source: 'native-auth-status' }
+      }
+    } catch { /* fail closed below */ }
+    return status?.credentialState?.source === 'native-runtime-unavailable'
+      ? status.credentialState
+      : { state: 'unknown', source: 'native-runtime-unavailable' }
   }
   if (kind !== 'claude' || !options.executable
       || Object.keys(nativeCredentialEnvironment(kind, options.env)).length) return current

--- a/desktop/src/local-workspace-agent-catalog.cjs
+++ b/desktop/src/local-workspace-agent-catalog.cjs
@@ -3,6 +3,31 @@ const {
   isReviewOnlyAgentKind,
 } = require('./agent-runtime-contract.cjs')
 
+const RECENT_VERIFICATION_MS = 24 * 60 * 60 * 1000
+
+function agentVersionIdentified(agent) {
+  if (agent?.custom === true) return true
+  if (typeof agent?.versionIdentified === 'boolean') return agent.versionIdentified
+  if (agent?.compatibilityState === 'unknown') return false
+  if (String(agent?.resolvedVersion || '').trim()) return true
+  if (agent?.compatibilityState === 'compatible') return true
+  return typeof agent?.compatibilityState === 'undefined'
+}
+
+function agentCompatible(agent) {
+  return agent?.custom === true
+    || agent?.compatibilityState === 'compatible'
+    || typeof agent?.compatibilityState === 'undefined'
+}
+
+function recentlyVerified(runtime, now) {
+  if (runtime?.credentialState !== 'ready') return false
+  const checkedAt = Date.parse(String(runtime.checkedAt || ''))
+  const current = Date.parse(String(now || ''))
+  return Number.isFinite(checkedAt) && Number.isFinite(current)
+    && current >= checkedAt && current - checkedAt <= RECENT_VERIFICATION_MS
+}
+
 class LocalWorkspaceAgentCatalog {
   constructor(options) {
     this.state = options.state
@@ -66,8 +91,24 @@ class LocalWorkspaceAgentCatalog {
       if (!runtimeMissing && sharedProviderReady) credentialState = 'ready'
       else if (!runtimeMissing && nativeState === 'ready') credentialState = 'ready'
       else if (!runtimeMissing && verifiedReady && nativeState !== 'missing') credentialState = 'ready'
-      const compatible = agent.custom === true || agent.compatibilityState !== 'incompatible'
-      const available = compatible && credentialState === 'ready'
+      const installed = true
+      const versionIdentified = agentVersionIdentified(agent)
+      const compatible = agentCompatible(agent)
+      const configured = sharedProviderReady
+        || nativeState === 'ready'
+        || native?.source === 'native-auth-status'
+        || native?.source === 'native-runtime-unavailable'
+        || verifiedReady
+        || runtimeMissing
+      const authenticated = !runtimeMissing && nativeState !== 'missing' && (
+        sharedProviderReady || nativeState === 'ready' || verifiedReady
+      )
+      const runtimePrerequisitesReady = native?.source !== 'native-runtime-unavailable'
+      const invocable = installed && versionIdentified && compatible && configured
+        && authenticated && runtimePrerequisitesReady
+      const verifiedRecently = (authoritativeNativeState && nativeState === 'ready')
+        || recentlyVerified(runtime, this.now())
+      const available = invocable
       const preferred = state.agentPreferences[agent.kind]?.showInSidebar
       const capabilities = agentRuntimeCapabilities(agent.kind)
       let availabilitySource = 'unverified'
@@ -79,7 +120,13 @@ class LocalWorkspaceAgentCatalog {
       else if (verifiedReady) availabilitySource = 'verified-run'
       return {
         ...agent,
-        installed: true,
+        installed,
+        versionIdentified,
+        compatible,
+        configured,
+        authenticated,
+        invocable,
+        recentlyVerified: verifiedRecently,
         credentialState,
         availabilitySource,
         available,
@@ -118,9 +165,15 @@ class LocalWorkspaceAgentCatalog {
     const agent = this.detectedAgents().find(item => item.kind === kind)
     if (agent) {
       agent.credentialState = credentialState
-      const compatible = agent.custom === true || agent.compatibilityState !== 'incompatible'
-      agent.available = compatible && credentialState === 'ready'
-      agent.availabilitySource = !compatible
+      agent.versionIdentified = agentVersionIdentified(agent)
+      agent.compatible = agentCompatible(agent)
+      agent.configured = credentialState !== 'unknown'
+      agent.authenticated = credentialState === 'ready'
+      agent.invocable = agent.versionIdentified && agent.compatible
+        && agent.configured && agent.authenticated
+      agent.recentlyVerified = credentialState === 'ready'
+      agent.available = agent.invocable
+      agent.availabilitySource = !agent.compatible
         ? 'incompatible'
         : credentialState === 'ready'
           ? 'verified-run'

--- a/desktop/src/main.cjs
+++ b/desktop/src/main.cjs
@@ -490,7 +490,15 @@ async function localAgentCatalog() {
       const support = localAttachmentSupport(agent.kind)
       return {
         ...agent,
-        available: Boolean(agent.installed && state?.available),
+        versionIdentified: Boolean(agent.installed && (state?.versionIdentified
+          ?? agent.versionIdentified ?? agent.resolvedVersion)),
+        compatible: Boolean(agent.installed && (state?.compatible
+          ?? agent.compatible ?? agent.compatibilityState === 'compatible')),
+        configured: Boolean(agent.installed && state?.configured),
+        authenticated: Boolean(agent.installed && state?.authenticated),
+        invocable: Boolean(agent.installed && state?.invocable),
+        recentlyVerified: Boolean(agent.installed && state?.recentlyVerified),
+        available: Boolean(agent.installed && state?.invocable),
         credentialState: agent.installed ? (state?.credentialState || 'unknown') : 'missing',
         availabilitySource: agent.installed ? (state?.availabilitySource || 'unverified') : 'none',
         showInSidebar: Boolean(agent.installed && state?.showInSidebar),

--- a/desktop/test/agent-compatibility.test.cjs
+++ b/desktop/test/agent-compatibility.test.cjs
@@ -6,6 +6,7 @@ const {
   assessAgentVersion,
   capabilityProbes,
   extractAgentVersion,
+  identifyAgentVersion,
 } = require('../src/agent-compatibility.cjs')
 
 test('extracts connector versions from decorated CLI output', () => {
@@ -15,6 +16,50 @@ test('extracts connector versions from decorated CLI output', () => {
   assert.equal(extractAgentVersion('OpenClaw 2026.7.1-2 (0790d9f)'), '2026.7.1-2')
   assert.equal(extractAgentVersion('open-code-review v1.8.6 darwin/arm64'), '1.8.6')
   assert.equal(extractAgentVersion('Please log in'), '')
+})
+
+test('identifies product versions without selecting unrelated warnings', () => {
+  assert.deepEqual(identifyAgentVersion('kimi', [
+    '\u001b[33mWarning: Node.js 22.5.1 is experimental\u001b[0m',
+    '\u001b[32mKimi Code 0.19.2\u001b[0m',
+  ], { executable: '/tmp/kimi' }), {
+    line: 'Kimi Code 0.19.2',
+    resolvedVersion: '0.19.2',
+  })
+  assert.deepEqual(identifyAgentVersion('kimi', [
+    'Warning: Node.js 22.5.1 is experimental',
+    '0.19.2',
+  ], { executable: '/tmp/kimi' }), {
+    line: '0.19.2',
+    resolvedVersion: '0.19.2',
+  })
+  assert.equal(identifyAgentVersion('kimi', [
+    'Kimi Code 0.19.2',
+    'Kimi Code 0.20.0',
+  ], { executable: '/tmp/kimi' }), null)
+  assert.equal(identifyAgentVersion('kimi', 'Node.js 22.5.1', {
+    executable: '/tmp/kimi',
+  }), null)
+  assert.deepEqual(identifyAgentVersion(
+    'kimi',
+    'Warning: Node.js 22.5.1 could not initialize Kimi Code 0.19.2',
+    { executable: '/tmp/kimi' },
+  ), {
+    line: 'Warning: Node.js 22.5.1 could not initialize Kimi Code 0.19.2',
+    resolvedVersion: '0.19.2',
+  })
+  assert.equal(identifyAgentVersion('kimi', '0.19.2', {
+    executable: '/tmp/not-kimi',
+  }), null)
+})
+
+test('keeps unidentified versions distinct from verified incompatibility', () => {
+  assert.deepEqual(assessAgentVersion('kimi', ''), {
+    resolvedVersion: '',
+    supportedVersionRange: '0.19.2..0.32.0',
+    compatibilityState: 'unknown',
+    incompatibilityReason: '',
+  })
 })
 
 test('accepts inclusive release ranges and rejects unvalidated versions', () => {

--- a/desktop/test/cli-adapters-discovery.test.cjs
+++ b/desktop/test/cli-adapters-discovery.test.cjs
@@ -581,7 +581,7 @@ test('Hermes detection records unavailable ACP when the capability check fails',
   }])
 })
 
-test('Agent detection ignores blank output and startup warnings before the version line', async () => {
+test('Agent detection ignores ANSI warnings with unrelated versions before the product version', async () => {
   const found = await detectAgents({
     platform: 'darwin',
     env: {},
@@ -592,8 +592,8 @@ test('Agent detection ignores blank output and startup warnings before the versi
       incompatibilityProbe: '',
     }),
     execFileFn: async () => ({
-      stdout: '  \n',
-      stderr: 'experimental startup warning\nKimi Code 0.19.2\n',
+      stdout: '\u001b[33mWarning: Node.js 22.5.1 is experimental\u001b[0m\n',
+      stderr: '\u001b[32mKimi Code 0.19.2\u001b[0m\n',
     }),
   })
 
@@ -796,14 +796,19 @@ test('Agent detection records the required capability or protocol that is unavai
   assert.equal(kimi[0].incompatibilityProbe, 'kimi-acp')
 })
 
-test('Agent detection retains installed CLIs with unrecognized version output as incompatible', async () => {
+test('Agent detection probes capabilities when the product version is unrecognized', async () => {
+  let calls = 0
   const found = await detectAgents({
     platform: 'darwin',
     env: {},
     resolveExecutableFn: async kind => kind === 'kimi' ? '/tmp/kimi' : null,
-    execFileFn: async () => ({ stdout: 'Please log in first\n', stderr: '' }),
+    execFileFn: async () => {
+      calls += 1
+      return { stdout: 'Please log in first\n', stderr: '' }
+    },
   })
 
+  assert.equal(calls, 3)
   assert.deepEqual(found, [{
     kind: 'kimi',
     name: 'Kimi CLI',
@@ -812,7 +817,41 @@ test('Agent detection retains installed CLIs with unrecognized version output as
     resolvedVersion: '',
     supportedVersionRange: '0.19.2..0.32.0',
     compatibilityState: 'incompatible',
-    incompatibilityReason: 'LOCAL_AGENT_VERSION_UNSUPPORTED',
+    incompatibilityReason: 'LOCAL_AGENT_REQUIRED_CAPABILITY_MISSING',
+    incompatibilityProbe: 'kimi-stream',
+  }])
+})
+
+test('Agent detection keeps ambiguous product versions unknown after successful capability probes', async () => {
+  let capabilityCalls = 0
+  const found = await detectAgents({
+    platform: 'darwin',
+    env: {},
+    resolveExecutableFn: async kind => kind === 'kimi' ? '/tmp/kimi' : null,
+    probeAgentCapabilitiesFn: async () => {
+      capabilityCalls += 1
+      return {
+        compatibilityState: 'compatible',
+        incompatibilityReason: '',
+        incompatibilityProbe: '',
+      }
+    },
+    execFileFn: async () => ({
+      stdout: 'Kimi Code 0.19.2\nKimi Code 0.20.0\n',
+      stderr: '',
+    }),
+  })
+
+  assert.equal(capabilityCalls, 1)
+  assert.deepEqual(found, [{
+    kind: 'kimi',
+    name: 'Kimi CLI',
+    executable: '/tmp/kimi',
+    version: '',
+    resolvedVersion: '',
+    supportedVersionRange: '0.19.2..0.32.0',
+    compatibilityState: 'unknown',
+    incompatibilityReason: '',
     incompatibilityProbe: '',
   }])
 })

--- a/desktop/test/local-agent-readiness.test.cjs
+++ b/desktop/test/local-agent-readiness.test.cjs
@@ -112,6 +112,16 @@ test('OpenClaw readiness uses the official model status when auth is stored outs
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'roundrelay-openclaw-readiness-'))
   const agentDir = path.join(home, '.openclaw', 'agents', 'main', 'agent')
   fs.mkdirSync(agentDir, { recursive: true })
+  fs.writeFileSync(path.join(agentDir, 'models.json'), JSON.stringify({
+    providers: {
+      provider: {
+        baseUrl: 'https://provider.example/v1',
+        api: 'openai-completions',
+        apiKey: 'native-openclaw-secret',
+        models: [{ id: 'model', name: 'Model', input: ['text'] }],
+      },
+    },
+  }))
   const calls = []
   try {
     const result = await resolveNativeCredentialState('openclaw', {
@@ -452,6 +462,14 @@ test('OpenClaw native runtime rejects unsafe status and Provider descriptors', a
       }),
       { message: 'OPENCLAW_NATIVE_RUNTIME_UNAVAILABLE' },
     )
+    assert.deepEqual(await resolveNativeCredentialState('openclaw', {
+      home,
+      env: {},
+      executable: '/tmp/openclaw',
+      execFileFn: async () => ({ stdout: JSON.stringify(status) }),
+    }), {
+      state: 'unknown', source: 'native-runtime-unavailable',
+    })
   }
 
   if (process.platform !== 'win32') {

--- a/desktop/test/local-workspace-agent-catalog.test.cjs
+++ b/desktop/test/local-workspace-agent-catalog.test.cjs
@@ -71,6 +71,7 @@ test('refresh starts credential checks concurrently and reads current runtime st
   const snapshot = await refresh
   assert.deepEqual(agents().map(agent => agent.kind), ['codex', 'hermes'])
   assert.deepEqual(snapshot.agents.map(agent => agent.credentialState), ['missing', 'ready'])
+  assert.deepEqual(snapshot.agents.map(agent => agent.invocable), [false, true])
   assert.equal(snapshot.agents[0].availabilitySource, 'runtime-auth-failure')
   assert.deepEqual(events, ['emit', 'snapshot'])
 })
@@ -81,6 +82,7 @@ test('incompatible Agents remain installed but unavailable with ready credential
       kind: 'codex',
       executable: '/tmp/codex',
       compatibilityState: 'incompatible',
+      resolvedVersion: '0.147.0',
       incompatibilityReason: 'LOCAL_AGENT_VERSION_UNSUPPORTED',
     }],
     credentialState: async () => ({ state: 'ready', source: 'native-auth-status' }),
@@ -90,6 +92,11 @@ test('incompatible Agents remain installed but unavailable with ready credential
   await catalog.refresh()
 
   assert.equal(agents()[0].installed, true)
+  assert.equal(agents()[0].versionIdentified, true)
+  assert.equal(agents()[0].compatible, false)
+  assert.equal(agents()[0].configured, true)
+  assert.equal(agents()[0].authenticated, true)
+  assert.equal(agents()[0].invocable, false)
   assert.equal(agents()[0].credentialState, 'ready')
   assert.equal(agents()[0].available, false)
   assert.equal(agents()[0].showInSidebar, false)
@@ -138,7 +145,63 @@ test('shared Provider readiness skips slow native credential probes', async () =
   assert.equal(nativeProbeCalls, 0)
   assert.equal(agents()[0].credentialState, 'ready')
   assert.equal(agents()[0].availabilitySource, 'shared-provider')
+  assert.equal(agents()[0].configured, true)
+  assert.equal(agents()[0].authenticated, true)
+  assert.equal(agents()[0].invocable, true)
+  assert.equal(agents()[0].recentlyVerified, false)
   assert.equal(agents()[0].available, true)
+})
+
+test('configured credentials do not make an Agent invocable when runtime prerequisites fail', async () => {
+  const { agents, catalog } = fixture({
+    detectAgents: async () => [{
+      kind: 'openclaw',
+      executable: '/tmp/openclaw',
+      resolvedVersion: '2026.7.1-2',
+      compatibilityState: 'compatible',
+    }],
+    credentialState: async () => ({
+      state: 'unknown', source: 'native-runtime-unavailable',
+    }),
+  })
+
+  await catalog.refresh()
+
+  assert.deepEqual(Object.fromEntries([
+    'installed', 'versionIdentified', 'compatible', 'configured', 'authenticated',
+    'invocable', 'recentlyVerified', 'available',
+  ].map(key => [key, agents()[0][key]])), {
+    installed: true,
+    versionIdentified: true,
+    compatible: true,
+    configured: true,
+    authenticated: false,
+    invocable: false,
+    recentlyVerified: false,
+    available: false,
+  })
+})
+
+test('unidentified product versions remain unavailable after credential validation', async () => {
+  const { agents, catalog } = fixture({
+    detectAgents: async () => [{
+      kind: 'kimi',
+      executable: '/tmp/kimi',
+      resolvedVersion: '',
+      compatibilityState: 'unknown',
+    }],
+    credentialState: async () => ({ state: 'ready', source: 'native-auth-status' }),
+  })
+
+  await catalog.refresh()
+
+  assert.equal(agents()[0].versionIdentified, false)
+  assert.equal(agents()[0].compatible, false)
+  assert.equal(agents()[0].configured, true)
+  assert.equal(agents()[0].authenticated, true)
+  assert.equal(agents()[0].invocable, false)
+  assert.equal(agents()[0].recentlyVerified, true)
+  assert.equal(agents()[0].available, false)
 })
 
 test('authoritative native validation persists recovery from a runtime auth failure', async () => {
@@ -156,6 +219,8 @@ test('authoritative native validation persists recovery from a runtime auth fail
     credentialState: 'ready', checkedAt: '2026-08-03T00:00:00.000Z',
   })
   assert.equal(agents()[0].credentialState, 'ready')
+  assert.equal(agents()[0].recentlyVerified, true)
+  assert.equal(agents()[0].invocable, true)
   assert.equal(agents()[0].available, true)
   assert.equal(agents()[0].availabilitySource, 'native-auth-status')
   assert.deepEqual(events, ['save', 'emit', 'snapshot'])


### PR DESCRIPTION
## Summary

- identify CLI versions by product across ANSI, stdout/stderr, warnings, and ambiguous multi-version output
- expose installed, version-identified, compatible, configured, authenticated, invocable, and recently verified states
- require OpenClaw readiness to pass the same guarded Agent directory, selected model, and models.json checks used by invocation
- route only Agents that are fully invocable; authoritative logout and incompatibility remain fail-closed

## Stability impact

This removes false-positive Agent availability. Unknown versions still receive capability probes, but cannot enter routing until product identity and compatibility are verified. OpenClaw credentials alone no longer imply a usable runtime.

## Verification

- `npm --prefix desktop test` (`921/921`)
- `npm --prefix desktop run pack`
- isolated packaged runtime: `desktop/dist/mac-arm64/Meldwork.app`
- packaged page: `file:.../app.asar/frontend/index.html#/chat`
- packaged User-Agent: Electron `39.8.10`
- catalog assertions: all seven readiness fields present; OpenClaw invocable; MiMo logged-out and OpenCodeReview `1.8.10` blocked from routing
- `git diff --check`

Closes #29
