### PR TITLE
feat(harness): add evidence-backed task graph orchestration

### DIFF
--- a/desktop/src/local-workspace-agent-invocation.cjs
+++ b/desktop/src/local-workspace-agent-invocation.cjs
@@ -730,7 +730,8 @@ class LocalWorkspaceAgentInvocation {
         ? isolated.promptOverride
         : [
             this.promptFor(
-              group, kind, mode, threadRootId, context.skillHints || [],
+              group, kind, context.completionPolicy === 'typed' ? 'manual' : mode,
+              threadRootId, context.skillHints || [],
               context.knowledgeBaseHints || [], afterKind, contextPackage, promptMode,
             ),
             stagedAgentInputPrompt(stagedInputs),
@@ -1108,7 +1109,7 @@ class LocalWorkspaceAgentInvocation {
       result = requireTerminalAgentResult(result)
       this.markRuntimeCredential(kind, 'ready')
 
-      const reply = mode === 'auto'
+      const reply = mode === 'auto' && context.completionPolicy !== 'typed'
         ? parseAutoReply(result.text)
         : { text: result.text, consensus: false }
       if (!reply.text) throw new Error('LOCAL_AGENT_EMPTY_RESPONSE')

--- a/desktop/src/local-workspace-auto-runner.cjs
+++ b/desktop/src/local-workspace-auto-runner.cjs
@@ -24,6 +24,13 @@ const {
   roleForIndex,
   visibleBlackboardEntries,
 } = require('./collaboration-records.cjs')
+const {
+  createTaskGraphCursor,
+  parseTaskGraphCursor,
+  readyTaskGraphNodes,
+  terminalTaskGraphState,
+  updateTaskGraphCursor,
+} = require('./task-graph-records.cjs')
 
 function authenticationFailureText(error) {
   return [
@@ -432,7 +439,7 @@ class LocalWorkspaceAutoRunner {
     const contract = this.retryContract(kind) || {}
     const idempotencyMode = contract.idempotencyMode === 'durable' ? 'durable' : 'none'
     const invokeSource = async () => {
-      this.setCurrentAgent(controller, kind)
+      if (context.parallelGraph !== true) this.setCurrentAgent(controller, kind)
       return this.invokeAgent(group, kind, mode, controller.signal, threadRootId, {
         ...context,
         deferCredentialFailure: true,
@@ -485,7 +492,24 @@ class LocalWorkspaceAutoRunner {
     }
   }
 
-  orchestrationCursor(targetKinds) {
+  orchestrationCursor(targetKinds, taskGraph = null) {
+    if (taskGraph) {
+      return {
+        version: 3,
+        workflow: 'auto',
+        template: 'task-graph',
+        currentKind: '',
+        pendingKinds: [...targetKinds],
+        activeKinds: [...targetKinds],
+        successfulKinds: [],
+        agreementKinds: [],
+        attachmentRecipients: [],
+        totalSuccesses: 0,
+        terminalFailureOccurred: false,
+        collaboration: emptyCollaborationState(),
+        taskGraph: createTaskGraphCursor(taskGraph),
+      }
+    }
     return {
       version: 2,
       workflow: 'auto',
@@ -547,24 +571,33 @@ class LocalWorkspaceAutoRunner {
       || 'Complete the current user task.'
   }
 
-  prepareCollaborationPackage(group, controller, activeKinds, kind, threadRootId) {
+  prepareCollaborationPackage(
+    group, controller, activeKinds, kind, threadRootId, options = {},
+  ) {
     const collaboration = controller.orchestration?.collaboration || emptyCollaborationState()
     const destination = {
       agentKind: kind,
-      role: this.collaborationRole(activeKinds, kind),
+      role: options.role || this.collaborationRole(activeKinds, kind),
     }
-    const selectedEntries = visibleBlackboardEntries(collaboration, destination)
+    const selectedEntryIds = Array.isArray(options.selectedEntryIds)
+      ? new Set(options.selectedEntryIds)
+      : null
+    const selectedEntries = selectedEntryIds
+      ? collaboration.entries.filter(entry => selectedEntryIds.has(entry.entryId))
+      : visibleBlackboardEntries(collaboration, destination)
     const objective = this.collaborationObjective(group, controller, threadRootId)
-    const expectedOutput = this.collaborationExpectedOutput(destination.role)
-    const acceptanceCriteria = this.collaborationAcceptance(destination.role)
-    const selectedEntryIds = selectedEntries.map(entry => entry.entryId)
+    const expectedOutput = options.expectedOutput
+      || this.collaborationExpectedOutput(destination.role)
+    const acceptanceCriteria = options.acceptanceCriteria
+      || this.collaborationAcceptance(destination.role)
+    const selectedIds = selectedEntries.map(entry => entry.entryId)
     const reusable = [...collaboration.handoffs].reverse().find(handoff => (
       handoff.destination.agentKind === destination.agentKind
       && handoff.destination.role === destination.role
       && handoff.objective === objective
       && handoff.expectedOutput === expectedOutput
-      && handoff.selectedEntryIds.length === selectedEntryIds.length
-      && handoff.selectedEntryIds.every((id, index) => id === selectedEntryIds[index])
+      && handoff.selectedEntryIds.length === selectedIds.length
+      && handoff.selectedEntryIds.every((id, index) => id === selectedIds[index])
       && handoff.acceptanceCriteria.length === acceptanceCriteria.length
       && handoff.acceptanceCriteria.every((value, index) => value === acceptanceCriteria[index])
     ))
@@ -583,7 +616,7 @@ class LocalWorkspaceAutoRunner {
       source: previousOwner || { type: 'harness' },
       destination,
       objective,
-      selectedEntryIds,
+      selectedEntryIds: selectedIds,
       expectedOutput,
       acceptanceCriteria,
       provenance: {
@@ -605,8 +638,8 @@ class LocalWorkspaceAutoRunner {
     }
   }
 
-  recordCollaborationResult(group, controller, activeKinds, kind, result) {
-    const role = this.collaborationRole(activeKinds, kind)
+  recordCollaborationResult(group, controller, activeKinds, kind, result, options = {}) {
+    const role = options.role || this.collaborationRole(activeKinds, kind)
     const conclusion = publicCollaborationText(result?.message?.content || '')
     const trace = result?.message?.trace
     const provenance = {
@@ -619,32 +652,36 @@ class LocalWorkspaceAutoRunner {
     }
     let collaboration = controller.orchestration?.collaboration || emptyCollaborationState()
     const previousCollaboration = collaboration
+    const previousEntryIds = new Set(collaboration.entries.map(entry => entry.entryId))
     let sequence = collaboration.entries.length + 1
     const recordedAt = Date.now()
     const conclusionValue = conclusion
       ? createHash('sha256').update(conclusion).digest('hex')
       : ''
+    const entryType = options.entryType || 'claim'
+    const subject = options.subject || `task:${controller.taskId}:conclusion`
+    const entryRefs = Array.isArray(options.refs) ? options.refs : []
     const duplicateConclusion = conclusion && collaboration.entries.some(entry => (
-      entry.entryType === 'claim'
+      entry.entryType === entryType
       && entry.lifecycle.state === 'active'
-      && entry.subject === `task:${controller.taskId}:conclusion`
+      && entry.subject === subject
       && entry.value === conclusionValue
       && entry.owner.type === 'agent'
       && entry.owner.agentKind === kind
     ))
     if (conclusion && !duplicateConclusion) {
       collaboration = appendBlackboardEntry(collaboration, {
-        entryType: 'claim',
-        subject: `task:${controller.taskId}:conclusion`,
+        entryType,
+        subject,
         statement: conclusion,
-        value: conclusionValue,
+        value: entryType === 'claim' ? conclusionValue : '',
         owner: { type: 'agent', agentKind: kind, role },
         audience: this.collaborationAudience(role),
         lifecycle: {
           state: 'active', sequence, recordedAt, supersedesEntryId: null,
         },
         provenance,
-        refs: [],
+        refs: entryRefs,
       })
       sequence = collaboration.entries.length + 1
     }
@@ -683,6 +720,9 @@ class LocalWorkspaceAutoRunner {
     if (collaboration !== previousCollaboration) {
       this.checkpointOrchestration(group, controller, { collaboration })
     }
+    return collaboration.entries
+      .filter(entry => !previousEntryIds.has(entry.entryId))
+      .map(entry => entry.entryId)
   }
 
   checkpointOrchestration(group, controller, updates = {}) {
@@ -691,6 +731,399 @@ class LocalWorkspaceAutoRunner {
     if (this.hasRunLedger() && persisted !== true) {
       throw new Error('LOCAL_RUN_PERSIST_FAILED')
     }
+  }
+
+  unresolvedTaskGraphConflicts(collaborationInput = null) {
+    const collaboration = collaborationInput || emptyCollaborationState()
+    const resolved = new Set(collaboration.entries
+      .filter(entry => entry.entryType === 'decision' && entry.lifecycle.state === 'active')
+      .flatMap(entry => entry.refs))
+    return collaboration.entries.filter(entry => (
+      entry.entryType === 'conflict'
+      && entry.lifecycle.state === 'active'
+      && !resolved.has(entry.entryId)
+    ))
+  }
+
+  taskGraphAcceptanceCriteria(node) {
+    const criteria = []
+    if (node.acceptance.requireConclusion) criteria.push('Return one concrete conclusion.')
+    if (node.acceptance.minArtifactRefs) {
+      criteria.push(`Produce at least ${node.acceptance.minArtifactRefs} durable Artifact reference(s).`)
+    }
+    if (node.acceptance.minEvidenceRefs) {
+      criteria.push(`Produce at least ${node.acceptance.minEvidenceRefs} durable Evidence reference(s).`)
+    }
+    return criteria.length ? criteria : ['Complete the explicit Human decision.']
+  }
+
+  taskGraphSelectedEntryIds(controller, node) {
+    const cursor = parseTaskGraphCursor(controller.orchestration.taskGraph)
+    const states = new Map(cursor.nodeStates.map(state => [state.nodeId, state]))
+    const selected = node.inputNodeIds.flatMap(nodeId => states.get(nodeId)?.entryIds || [])
+    if (['reviewer', 'arbiter'].includes(node.role)) {
+      selected.push(...this.unresolvedTaskGraphConflicts(
+        controller.orchestration.collaboration,
+      ).map(entry => entry.entryId))
+    }
+    return [...new Set(selected)]
+  }
+
+  taskGraphPrompt(node, objective, collaborationPackage) {
+    return [
+      'ROUNDRELAY_TASK_GRAPH_V1',
+      `Node: ${node.nodeId}`,
+      `Role: ${node.role}`,
+      `Objective: ${objective}`,
+      `Expected output: ${node.expectedOutput}`,
+      `Acceptance criteria: ${this.taskGraphAcceptanceCriteria(node).join(' | ')}`,
+      collaborationPackage.text,
+      'Return the requested result directly. Completion is evaluated from durable typed records; do not emit a consensus marker.',
+    ].join('\n')
+  }
+
+  checkpointTaskGraph(group, controller, cursorInput, options = {}) {
+    let taskGraph = parseTaskGraphCursor(cursorInput)
+    taskGraph = parseTaskGraphCursor({
+      ...taskGraph,
+      terminalState: terminalTaskGraphState(taskGraph),
+    })
+    const states = new Map(taskGraph.nodeStates.map(state => [state.nodeId, state]))
+    const pendingKinds = taskGraph.graph.nodes
+      .filter(node => states.get(node.nodeId)?.status === 'pending' && node.agentKind)
+      .map(node => node.agentKind)
+    const successfulKinds = taskGraph.graph.nodes
+      .filter(node => states.get(node.nodeId)?.status === 'accepted' && node.agentKind)
+      .map(node => node.agentKind)
+    const uniquePendingKinds = [...new Set(pendingKinds)]
+    const uniqueSuccessfulKinds = [...new Set(successfulKinds)]
+    this.checkpointOrchestration(group, controller, {
+      taskGraph,
+      currentKind: options.currentKind || '',
+      pendingKinds: uniquePendingKinds,
+      successfulKinds: uniqueSuccessfulKinds,
+      agreementKinds: [],
+      totalSuccesses: taskGraph.nodeStates.filter(state => state.status === 'accepted').length,
+      terminalFailureOccurred: taskGraph.terminalState === 'failed',
+    })
+    return taskGraph
+  }
+
+  taskGraphResultAccepted(node, result) {
+    const conclusion = publicCollaborationText(result?.message?.content || '')
+    const artifactIds = result?.outcomeRefs?.artifactIds || []
+    const evidenceIds = result?.outcomeRefs?.evidenceIds || []
+    return (!node.acceptance.requireConclusion || Boolean(conclusion))
+      && artifactIds.length >= node.acceptance.minArtifactRefs
+      && evidenceIds.length >= node.acceptance.minEvidenceRefs
+  }
+
+  applyTaskGraphAgentResult(group, controller, node, result) {
+    const conflicts = this.unresolvedTaskGraphConflicts(controller.orchestration.collaboration)
+    const entryIds = this.recordCollaborationResult(
+      group,
+      controller,
+      controller.orchestration.activeKinds,
+      node.agentKind,
+      result,
+      {
+        role: node.role,
+        entryType: node.role === 'arbiter' ? 'decision' : 'claim',
+        subject: node.role === 'primary'
+          ? `task:${controller.taskId}:conclusion`
+          : `task:${controller.taskId}:node:${node.nodeId}`,
+        refs: node.role === 'arbiter' ? conflicts.map(entry => entry.entryId) : [],
+      },
+    )
+    const accepted = this.taskGraphResultAccepted(node, result)
+    const conclusion = publicCollaborationText(result?.message?.content || '')
+    const artifactIds = result?.outcomeRefs?.artifactIds || []
+    const evidenceIds = result?.outcomeRefs?.evidenceIds || []
+    let cursor = updateTaskGraphCursor(
+      controller.orchestration.taskGraph,
+      node.nodeId,
+      {
+        status: accepted ? 'accepted' : 'failed',
+        entryIds,
+        artifactIds,
+        evidenceIds,
+        conclusionHash: conclusion
+          ? createHash('sha256').update(conclusion).digest('hex')
+          : '',
+      },
+    )
+    if (accepted) {
+      if (!controller.completedKinds.includes(node.agentKind)) {
+        controller.completedKinds.push(node.agentKind)
+      }
+    } else if (!controller.failedKinds.includes(node.agentKind)) {
+      controller.failedKinds.push(node.agentKind)
+    }
+    cursor = this.checkpointTaskGraph(group, controller, cursor)
+    return accepted
+  }
+
+  taskGraphDecisionAgentRunId(graphId, nodeId) {
+    const digest = createHash('sha256').update(JSON.stringify([graphId, nodeId])).digest('hex')
+    return `graph-decision-${digest}`
+  }
+
+  taskGraphDecisionAnchor(controller, node) {
+    const graph = parseTaskGraphCursor(controller.orchestration.taskGraph)
+    const byId = new Map(graph.graph.nodes.map(candidate => [candidate.nodeId, candidate]))
+    return [...node.dependsOn].reverse()
+      .map(nodeId => byId.get(nodeId)?.agentKind)
+      .find(Boolean) || controller.targetKinds[0]
+  }
+
+  applyTaskGraphHumanDecision(group, controller, node, decision) {
+    const option = node.decisionOptions.find(candidate => candidate.optionId === decision.optionId)
+    if (!option) throw new Error('LOCAL_WORKFLOW_DECISION_INVALID')
+    const accepted = decision.status === 'approved'
+    const conflicts = this.unresolvedTaskGraphConflicts(controller.orchestration.collaboration)
+    let collaboration = controller.orchestration.collaboration
+    collaboration = appendBlackboardEntry(collaboration, {
+      entryType: 'decision',
+      subject: `task:${controller.taskId}:node:${node.nodeId}`,
+      statement: `Human selected: ${option.name}`,
+      value: '',
+      owner: { type: 'harness' },
+      audience: { roles: ['primary', 'reviewer', 'arbiter'], agentKinds: [] },
+      lifecycle: {
+        state: 'active',
+        sequence: collaboration.entries.length + 1,
+        recordedAt: Date.now(),
+        supersedesEntryId: null,
+      },
+      provenance: {
+        runId: controller.runId,
+        taskId: controller.taskId,
+        round: controller.currentRound,
+        agentRunId: this.taskGraphDecisionAgentRunId(
+          controller.orchestration.taskGraph.graph.graphId,
+          node.nodeId,
+        ),
+        artifactIds: [],
+        evidenceIds: [],
+      },
+      refs: conflicts.map(entry => entry.entryId),
+    })
+    const decisionEntryId = collaboration.entries.at(-1).entryId
+    this.checkpointOrchestration(group, controller, { collaboration })
+    let cursor = updateTaskGraphCursor(
+      controller.orchestration.taskGraph,
+      node.nodeId,
+      {
+        status: accepted ? 'accepted' : 'rejected',
+        entryIds: [decisionEntryId],
+        decisionOptionId: option.optionId,
+      },
+    )
+    cursor = this.checkpointTaskGraph(group, controller, cursor)
+    return accepted
+  }
+
+  async executeTaskGraphAgentNode(
+    group, controller, threadRootId, context, node, parallelGraph = false,
+  ) {
+    const selectedEntryIds = this.taskGraphSelectedEntryIds(controller, node)
+    const collaborationPackage = this.prepareCollaborationPackage(
+      group,
+      controller,
+      controller.orchestration.activeKinds,
+      node.agentKind,
+      threadRootId,
+      {
+        role: node.role,
+        selectedEntryIds,
+        expectedOutput: node.expectedOutput,
+        acceptanceCriteria: this.taskGraphAcceptanceCriteria(node),
+      },
+    )
+    const isolated = ['reviewer', 'arbiter'].includes(node.role)
+    const attachments = node.role === 'primary'
+      && !controller.orchestration.attachmentRecipients.includes(node.agentKind)
+      ? context.rootAttachments.map(attachment => attachment.path)
+      : []
+    const objective = this.collaborationObjective(group, controller, threadRootId)
+    return this.invokeWithUnauthorizedRecovery({
+      group,
+      kind: node.agentKind,
+      controller,
+      threadRootId,
+      context: {
+        attachments,
+        attachmentSnapshots: attachments.length ? context.rootAttachments : [],
+        skillHints: context.rootSkillsByKind.get(node.agentKind) || [],
+        knowledgeBaseHints: context.rootKnowledgeBasesByKind.get(node.agentKind) || [],
+        collaborationPackage,
+        completionPolicy: 'typed',
+        parallelGraph,
+        runtimeInstruction: isolated ? '' : [
+          `Execute task-graph node ${node.nodeId} as ${node.role}.`,
+          `Expected output: ${node.expectedOutput}`,
+          'Do not emit a consensus marker.',
+        ].join('\n'),
+        ...(isolated ? {
+          sessionPolicy: 'isolated',
+          promptOverride: this.taskGraphPrompt(node, objective, collaborationPackage),
+          contextPackId: controller.contextPackId,
+        } : {}),
+        contextOptions: {
+          focusUserMessageId: threadRootId,
+          omitAgentThreadRootId: threadRootId,
+        },
+      },
+      mode: 'auto',
+    })
+  }
+
+  async executeTaskGraphHumanNode(group, controller, node) {
+    if (!this.requestHumanGate) throw new Error('LOCAL_WORKFLOW_DECISION_UNAVAILABLE')
+    const anchorKind = this.taskGraphDecisionAnchor(controller, node)
+    const agentRunId = this.taskGraphDecisionAgentRunId(
+      controller.orchestration.taskGraph.graph.graphId,
+      node.nodeId,
+    )
+    let cursor = updateTaskGraphCursor(
+      controller.orchestration.taskGraph,
+      node.nodeId,
+      { status: 'waiting', attention: 'decision', attempts: 1 },
+    )
+    cursor = this.checkpointTaskGraph(group, controller, cursor, { currentKind: anchorKind })
+    const gate = await this.requestHumanGate({
+      type: 'decision',
+      runId: controller.runId,
+      agentRunId,
+      agentKind: anchorKind,
+      summary: node.expectedOutput,
+      options: node.decisionOptions,
+      request: {
+        graphId: cursor.graph.graphId,
+        nodeId: node.nodeId,
+        inputNodeIds: node.inputNodeIds,
+      },
+    }, {
+      signal: controller.signal,
+      preserveOnAbort: () => controller.stopReason === 'shutdown',
+      continuation: {
+        resumeKind: 'role_review_decision',
+        agentRunId,
+        agentKind: anchorKind,
+        round: controller.currentRound,
+      },
+    })
+    const accepted = this.applyTaskGraphHumanDecision(group, controller, node, gate)
+    if (this.completeHumanGateContinuation?.(
+      controller.runId,
+      gate.gateId,
+      accepted ? 'completed' : 'cancelled',
+    ) !== true && this.hasRunLedger()) {
+      throw new Error('LOCAL_RUN_PERSIST_FAILED')
+    }
+    return accepted
+  }
+
+  taskGraphBatch(group, readyNodes) {
+    const parallel = []
+    const kinds = new Set()
+    if (group.allowWrite !== true) {
+      for (const node of readyNodes) {
+        if (!node.parallel || node.role === 'human' || kinds.has(node.agentKind)) continue
+        parallel.push(node)
+        kinds.add(node.agentKind)
+      }
+    }
+    return parallel.length > 1 ? parallel : readyNodes.slice(0, 1)
+  }
+
+  async runTaskGraph(group, controller, threadRootId, context) {
+    while (!controller.signal.aborted) {
+      let cursor = parseTaskGraphCursor(controller.orchestration.taskGraph)
+      const terminalState = terminalTaskGraphState(cursor)
+      if (terminalState !== 'running') {
+        cursor = this.checkpointTaskGraph(group, controller, cursor)
+        break
+      }
+      if (!controller.unlimitedRounds && controller.currentRound >= controller.maxRounds) break
+      const readyNodes = readyTaskGraphNodes(cursor)
+      if (!readyNodes.length) {
+        cursor = parseTaskGraphCursor({ ...cursor, terminalState: 'failed' })
+        this.checkpointTaskGraph(group, controller, cursor)
+        break
+      }
+      const batch = this.taskGraphBatch(group, readyNodes)
+      controller.currentRound += 1
+      if (batch.length === 1 && batch[0].role === 'human') {
+        await this.executeTaskGraphHumanNode(group, controller, batch[0])
+        continue
+      }
+      const conflicts = this.unresolvedTaskGraphConflicts(controller.orchestration.collaboration)
+      for (const node of batch) {
+        cursor = updateTaskGraphCursor(cursor, node.nodeId, {
+          status: 'running',
+          attention: node.role === 'reviewer' && conflicts.length
+            ? 'review'
+            : (node.role === 'arbiter' && conflicts.length ? 'decision' : 'none'),
+          attempts: cursor.nodeStates.find(state => state.nodeId === node.nodeId).attempts + 1,
+        })
+      }
+      const currentKind = batch.length === 1 ? batch[0].agentKind : ''
+      cursor = this.checkpointTaskGraph(group, controller, cursor, { currentKind })
+      this.emitChanged()
+      const settled = await Promise.allSettled(batch.map(node => (
+        this.executeTaskGraphAgentNode(
+          group, controller, threadRootId, context, node, batch.length > 1,
+        )
+      )))
+      for (let index = 0; index < batch.length; index += 1) {
+        const node = batch[index]
+        const outcome = settled[index]
+        if (outcome.status === 'fulfilled' && outcome.value?.result) {
+          if (outcome.value.result.outcomeRefs?.artifactIds?.length
+              && !controller.orchestration.attachmentRecipients.includes(node.agentKind)) {
+            this.checkpointOrchestration(group, controller, {
+              attachmentRecipients: [...controller.orchestration.attachmentRecipients, node.agentKind],
+            })
+          }
+          this.applyTaskGraphAgentResult(group, controller, node, outcome.value.result)
+          continue
+        }
+        const error = outcome.status === 'rejected'
+          ? outcome.reason
+          : (outcome.value?.error || new Error('LOCAL_AGENT_UNKNOWN_FAILURE'))
+        if (controller.signal.aborted) continue
+        this.recordAgentFailure(group.id, node.agentKind, error, threadRootId, new Set())
+        cursor = updateTaskGraphCursor(
+          controller.orchestration.taskGraph,
+          node.nodeId,
+          { status: 'failed' },
+        )
+        this.checkpointTaskGraph(group, controller, cursor)
+        if (!controller.failedKinds.includes(node.agentKind)) {
+          controller.failedKinds.push(node.agentKind)
+        }
+        if (circuitBreakerFailure(error)) {
+          controller.stopReason = 'circuit_breaker'
+          controller.abort()
+        } else if (hardBudgetFailure(error)) {
+          controller.stopReason = 'hard_budget'
+          controller.abort()
+        }
+      }
+      controller.currentKind = ''
+      controller.progress = []
+      this.emitChanged()
+    }
+
+    if (controller.signal.aborted) return terminalRunStatusForReason(controller.stopReason)
+    const cursor = parseTaskGraphCursor(controller.orchestration.taskGraph)
+    if (cursor.terminalState === 'accepted') return 'completed'
+    if (cursor.terminalState === 'rejected') return 'stopped'
+    if (cursor.terminalState === 'failed') {
+      return cursor.nodeStates.some(state => state.status === 'accepted') ? 'partial' : 'failed'
+    }
+    return cursor.nodeStates.some(state => state.status === 'accepted') ? 'round-limit' : 'failed'
   }
 
   async automaticContext(group, controller, threadRootId, preparedContext = null) {
@@ -1041,9 +1474,9 @@ class LocalWorkspaceAutoRunner {
 
   start(
     group, targetKinds, threadRootId, maxRounds, reservation = null, preparedContext = null,
-    unlimitedRounds = false,
+    unlimitedRounds = false, taskGraph = null,
   ) {
-    reservation.orchestration = this.orchestrationCursor(targetKinds)
+    reservation.orchestration = this.orchestrationCursor(targetKinds, taskGraph)
     const controller = this.beginRun(
       group.id, 'auto', targetKinds, threadRootId, reservation, maxRounds, unlimitedRounds,
     )
@@ -1053,9 +1486,9 @@ class LocalWorkspaceAutoRunner {
         const context = await this.automaticContext(
           group, controller, threadRootId, preparedContext,
         )
-        runStatus = await this.runRounds(
-          group, controller, threadRootId, maxRounds, context,
-        )
+        runStatus = taskGraph
+          ? await this.runTaskGraph(group, controller, threadRootId, context)
+          : await this.runRounds(group, controller, threadRootId, maxRounds, context)
       } catch (error) {
         runStatus = controller.signal.aborted
           ? terminalRunStatusForReason(controller.stopReason)
@@ -1089,7 +1522,21 @@ class LocalWorkspaceAutoRunner {
     return controller
   }
 
-  async resume(group, durable, controller) {
+  async resume(group, durable, controller, replayedResult = null) {
+    if (controller.orchestration?.version === 3) {
+      const cursor = parseTaskGraphCursor(controller.orchestration.taskGraph)
+      const runningNodeId = cursor.currentNodeIds.length === 1
+        ? cursor.currentNodeIds[0]
+        : ''
+      const node = cursor.graph.nodes.find(candidate => candidate.nodeId === runningNodeId)
+      if (replayedResult && node?.role !== 'human') {
+        this.applyTaskGraphAgentResult(group, controller, node, replayedResult)
+      }
+      const context = await this.automaticContext(
+        group, controller, durable.threadRootId, null,
+      )
+      return this.runTaskGraph(group, controller, durable.threadRootId, context)
+    }
     if (controller.orchestration?.version === 1) {
       controller.orchestration = {
         ...controller.orchestration,
@@ -1107,6 +1554,29 @@ class LocalWorkspaceAutoRunner {
     return this.runRounds(
       group, controller, durable.threadRootId, durable.maxRounds, context, true,
     )
+  }
+
+  async resumeDecision(group, durable, controller, decision) {
+    const cursor = parseTaskGraphCursor(controller.orchestration?.taskGraph)
+    const waiting = cursor.nodeStates.find(state => state.status === 'waiting')
+    const node = cursor.graph.nodes.find(candidate => candidate.nodeId === waiting?.nodeId)
+    if (!node || node.role !== 'human') throw new Error('LOCAL_RUN_CONTINUATION_INVALID')
+    const expectedAgentRunId = this.taskGraphDecisionAgentRunId(cursor.graph.graphId, node.nodeId)
+    if (durable.continuation?.agentRunId !== expectedAgentRunId) {
+      throw new Error('LOCAL_RUN_CONTINUATION_INVALID')
+    }
+    const accepted = this.applyTaskGraphHumanDecision(group, controller, node, decision)
+    if (this.completeHumanGateContinuation?.(
+      controller.runId,
+      durable.continuation.gateId,
+      accepted ? 'completed' : 'cancelled',
+    ) !== true && this.hasRunLedger()) {
+      throw new Error('LOCAL_RUN_PERSIST_FAILED')
+    }
+    const context = await this.automaticContext(
+      group, controller, durable.threadRootId, null,
+    )
+    return this.runTaskGraph(group, controller, durable.threadRootId, context)
   }
 }
 

--- a/desktop/src/local-workspace-message-submission.cjs
+++ b/desktop/src/local-workspace-message-submission.cjs
@@ -19,6 +19,7 @@ const {
 } = require('./local-workspace-inputs.cjs')
 const { MAX_RUN_AGENT_ATTEMPTS } = require('./failure-policy.cjs')
 const { mediaGenerationRequest } = require('./media-generation-request.cjs')
+const { createTaskGraph } = require('./task-graph-records.cjs')
 
 function hardBudgetFailure(error) {
   return error?.code === 'LOCAL_BUDGET_EXHAUSTED'
@@ -236,6 +237,18 @@ class LocalWorkspaceMessageSubmission {
     const maxRounds = mode === 'auto' && !unlimitedRounds
       ? normalizeAutoRounds(input.maxRounds ?? input.maxTurns)
       : 0
+    let taskGraph = null
+    if (input.workflow != null) {
+      if (mode !== 'auto') throw new Error('LOCAL_WORKFLOW_UNSUPPORTED')
+      if (input.workflow?.template !== 'task-graph') {
+        throw new Error('LOCAL_WORKFLOW_UNSUPPORTED')
+      }
+      try {
+        taskGraph = createTaskGraph(input.workflow, targetKinds)
+      } catch {
+        throw new Error('LOCAL_WORKFLOW_INVALID')
+      }
+    }
     const requestedThreadRootId = mode === 'manual' ? cleanText(input.threadRootId, 100) : ''
     const regenerateMessageId = cleanText(input.regenerateMessageId, 100)
     if (input.regenerateMessageId != null && !regenerateMessageId) {
@@ -252,6 +265,7 @@ class LocalWorkspaceMessageSubmission {
       requestedThreadRootId,
       regenerateMessageId,
       routingDecision,
+      taskGraph,
     }
   }
 
@@ -340,6 +354,7 @@ class LocalWorkspaceMessageSubmission {
       requestedThreadRootId,
       regenerateMessageId,
       routingDecision,
+      taskGraph,
     } = this.validateInput(group, input)
     const regeneration = this.resolveRegeneration(group, regenerateMessageId, targetKinds)
     const reservation = this.reserveRun(
@@ -401,6 +416,7 @@ class LocalWorkspaceMessageSubmission {
             )
             controller = this.startAutoRunner(
               group, targetKinds, userMessage.id, maxRounds, reservation, prepared, unlimitedRounds,
+              taskGraph,
             )
           } catch (error) {
             try {
@@ -664,6 +680,17 @@ class LocalWorkspaceMessageSubmission {
     const maxRounds = unlimitedRounds
       ? 0
       : normalizeAutoRounds(input.maxRounds ?? input.maxTurns)
+    let taskGraph = null
+    if (input.workflow != null) {
+      if (input.workflow?.template !== 'task-graph') {
+        throw new Error('LOCAL_WORKFLOW_UNSUPPORTED')
+      }
+      try {
+        taskGraph = createTaskGraph(input.workflow, targetKinds)
+      } catch {
+        throw new Error('LOCAL_WORKFLOW_INVALID')
+      }
+    }
     const state = this.state()
     const latestRoot = state.messages.findLast(message => (
       message.groupId === group.id && message.role === 'user' && !message.threadRootId
@@ -694,6 +721,7 @@ class LocalWorkspaceMessageSubmission {
       )
       this.startAutoRunner(
         group, targetKinds, threadRootId, maxRounds, reservation, null, unlimitedRounds,
+        taskGraph,
       )
     } catch (error) {
       this.releasePreparation(group.id, reservation)

--- a/desktop/src/local-workspace.cjs
+++ b/desktop/src/local-workspace.cjs
@@ -592,7 +592,7 @@ class LocalWorkspace extends EventEmitter {
     const cursor = durable?.orchestration
     const continuation = durable?.continuation
     const supportedCursor = workflow === 'auto'
-      ? [1, 2].includes(cursor?.version)
+      ? [1, 2, 3].includes(cursor?.version)
       : cursor?.version === 1
     if (durable?.mode !== workflow || !supportedCursor || cursor.workflow !== workflow
         || cursor.currentKind !== continuation?.agentKind
@@ -830,6 +830,10 @@ class LocalWorkspace extends EventEmitter {
       const group = this.getGroup(durable.groupId)
       const resumableManual = this.canResumeManualOrchestration(durable)
       const resumableAuto = this.canResumeAutoOrchestration(durable)
+      const resumableTaskGraphDecision = durable.continuation.resumeKind === 'role_review_decision'
+        && durable.mode === 'auto'
+        && durable.orchestration?.version === 3
+        && durable.orchestration?.template === 'task-graph'
       if (durable.continuation.resumeKind === 'agent_slot'
           && decision.status === 'approved'
           && !this.canFinalizeReplayedAgentSlot(durable)
@@ -837,8 +841,16 @@ class LocalWorkspace extends EventEmitter {
           && !resumableAuto) {
         throw new Error('LOCAL_RUN_ORCHESTRATION_RESUME_UNAVAILABLE')
       }
-      if (durable.continuation.resumeKind === 'role_review_decision') {
+      if (durable.continuation.resumeKind === 'role_review_decision'
+          && !resumableTaskGraphDecision) {
         throw new Error('LOCAL_WORKFLOW_UNSUPPORTED')
+      }
+      if (resumableTaskGraphDecision) {
+        const finalStatus = await this.autoRunner.resumeDecision(
+          group, durable, controller, decision,
+        )
+        await this.finishRun(durable.groupId, controller, finalStatus)
+        return
       }
       const request = this.humanGateStore.request(gate.gateId)
       let replayedResult = null
@@ -898,7 +910,7 @@ class LocalWorkspace extends EventEmitter {
       const finalStatus = resumableManual
         ? await this.continueManualOrchestration(group, durable, controller)
         : (resumableAuto
-            ? await this.autoRunner.resume(group, durable, controller)
+            ? await this.autoRunner.resume(group, durable, controller, replayedResult)
             : 'completed')
       await this.finishRun(durable.groupId, controller, finalStatus)
     } catch (error) {
@@ -1312,15 +1324,15 @@ class LocalWorkspace extends EventEmitter {
 
   startAutoRunner(
     group, targetKinds, threadRootId, maxRounds, reservation = null, preparedContext = null,
-    unlimitedRounds = false,
+    unlimitedRounds = false, taskGraph = null,
   ) {
     return this.autoRunner.start(
       group, targetKinds, threadRootId, maxRounds, reservation, preparedContext, unlimitedRounds,
+      taskGraph,
     )
   }
 
   async sendMessage(input) {
-    if (input?.workflow) throw new Error('LOCAL_WORKFLOW_UNSUPPORTED')
     return this.messageSubmission.send(input)
   }
 

--- a/desktop/src/run-ledger-records.cjs
+++ b/desktop/src/run-ledger-records.cjs
@@ -26,6 +26,7 @@ const {
   normalizeAttemptHistory,
 } = require('./failure-policy.cjs')
 const { parseCollaborationState } = require('./collaboration-records.cjs')
+const { parseTaskGraphCursor } = require('./task-graph-records.cjs')
 
 const DEFAULT_MAX_DURABLE_AGENT_RUNS = 256
 const MAX_TARGET_KINDS = 32
@@ -64,7 +65,7 @@ const CONTINUATION_STATES = new Set([
 const ORCHESTRATION_FIELDS = new Set([
   'version', 'workflow', 'currentKind', 'pendingKinds', 'activeKinds',
   'successfulKinds', 'agreementKinds', 'attachmentRecipients',
-  'totalSuccesses', 'terminalFailureOccurred', 'collaboration',
+  'totalSuccesses', 'terminalFailureOccurred', 'collaboration', 'template', 'taskGraph',
 ])
 const ORCHESTRATION_WORKFLOWS = new Set(['manual', 'auto'])
 
@@ -403,13 +404,25 @@ function normalizeOrchestration(input) {
   const agreementKinds = normalizeKinds(input.agreementKinds)
   const attachmentRecipients = normalizeKinds(input.attachmentRecipients)
   const totalSuccesses = boundedNumber(input.totalSuccesses, 0, 1000000)
-  if (![1, 2].includes(version) || !ORCHESTRATION_WORKFLOWS.has(workflow)
+  if (![1, 2, 3].includes(version) || !ORCHESTRATION_WORKFLOWS.has(workflow)
       || (version === 1 && hasOwn(input, 'collaboration'))
-      || (version === 2 && workflow !== 'auto')) return undefined
+      || (version === 2 && workflow !== 'auto')
+      || (version < 3 && (hasOwn(input, 'template') || hasOwn(input, 'taskGraph')))
+      || (version === 3 && (workflow !== 'auto' || input.template !== 'task-graph'))) {
+    return undefined
+  }
   let collaboration
-  if (version === 2) {
+  if (version >= 2) {
     try {
       collaboration = parseCollaborationState(input.collaboration)
+    } catch {
+      return undefined
+    }
+  }
+  let taskGraph
+  if (version === 3) {
+    try {
+      taskGraph = parseTaskGraphCursor(input.taskGraph)
     } catch {
       return undefined
     }
@@ -425,7 +438,8 @@ function normalizeOrchestration(input) {
     attachmentRecipients,
     totalSuccesses,
     terminalFailureOccurred: input.terminalFailureOccurred === true,
-    ...(version === 2 ? { collaboration } : {}),
+    ...(version >= 2 ? { collaboration } : {}),
+    ...(version === 3 ? { template: 'task-graph', taskGraph } : {}),
   }
 }
 
@@ -505,6 +519,7 @@ function hasValidStoredRecordShape(input) {
     ...orchestration.successfulKinds,
     ...orchestration.agreementKinds,
     ...orchestration.attachmentRecipients,
+    ...(orchestration.taskGraph?.graph.nodes.map(node => node.agentKind) || []),
   ].filter(Boolean).some(kind => !targetKinds.includes(kind))) return false
   const parent = {
     runId: cleanId(input.runId),
@@ -752,6 +767,7 @@ function normalizeRecord(input, options = {}) {
     ...orchestration.successfulKinds,
     ...orchestration.agreementKinds,
     ...orchestration.attachmentRecipients,
+    ...(orchestration.taskGraph?.graph.nodes.map(node => node.agentKind) || []),
   ].filter(Boolean).some(kind => !targetKinds.includes(kind))) return null
 
   const record = {

--- a/desktop/src/task-graph-records.cjs
+++ b/desktop/src/task-graph-records.cjs
@@ -1,0 +1,271 @@
+const { createHash } = require('node:crypto')
+const { z } = require('zod')
+
+const { canonicalJson } = require('./context-pack-records.cjs')
+const { redactSecrets } = require('./secret-redaction.cjs')
+
+const TASK_GRAPH_VERSION = 1
+const TASK_GRAPH_CURSOR_VERSION = 1
+const MAX_GRAPH_NODES = 32
+const PUBLIC_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$/
+const GRAPH_ID = /^task-graph-[a-f0-9]{64}$/
+const OUTCOME_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,119}$/
+const SHA256 = /^[a-f0-9]{64}$/
+const ROLES = ['primary', 'reviewer', 'arbiter', 'human']
+const STATUSES = ['pending', 'running', 'waiting', 'accepted', 'rejected', 'failed']
+const ATTENTION_STATES = ['none', 'review', 'decision']
+const TERMINAL_STATES = ['running', 'accepted', 'rejected', 'failed']
+
+function taskGraphError(code) {
+  return Object.assign(new Error(code), { code })
+}
+
+function fail(code) {
+  throw taskGraphError(code)
+}
+
+function uniqueArray(schema, max = MAX_GRAPH_NODES) {
+  return z.array(schema).max(max).superRefine((values, context) => {
+    if (new Set(values).size !== values.length) {
+      context.addIssue({ code: 'custom', message: 'duplicate value' })
+    }
+  })
+}
+
+const publicIdSchema = z.string().regex(PUBLIC_ID)
+const boundedTextSchema = z.string().min(1).max(2000).superRefine((value, context) => {
+  if (redactSecrets(value) !== value || /[\u0000-\u001f\u007f]/u.test(value)) {
+    context.addIssue({ code: 'custom', message: 'unsafe text' })
+  }
+})
+const acceptanceSchema = z.strictObject({
+  requireConclusion: z.boolean(),
+  minArtifactRefs: z.number().int().min(0).max(16),
+  minEvidenceRefs: z.number().int().min(0).max(16),
+})
+const decisionOptionSchema = z.strictObject({
+  optionId: publicIdSchema,
+  name: z.string().min(1).max(160),
+  kind: z.enum(['allow_once', 'reject_once']),
+})
+const nodeContentFields = {
+  nodeId: publicIdSchema,
+  role: z.enum(ROLES),
+  agentKind: publicIdSchema.nullable(),
+  dependsOn: uniqueArray(publicIdSchema),
+  inputNodeIds: uniqueArray(publicIdSchema),
+  expectedOutput: boundedTextSchema,
+  acceptance: acceptanceSchema,
+  terminal: z.boolean(),
+  parallel: z.boolean(),
+  decisionOptions: uniqueArray(decisionOptionSchema, 16),
+}
+const nodeSchema = z.strictObject(nodeContentFields).superRefine((node, context) => {
+  if (node.inputNodeIds.some(nodeId => !node.dependsOn.includes(nodeId))) {
+    context.addIssue({ code: 'custom', path: ['inputNodeIds'], message: 'input must be a dependency' })
+  }
+  if (node.dependsOn.includes(node.nodeId)) {
+    context.addIssue({ code: 'custom', path: ['dependsOn'], message: 'self dependency' })
+  }
+  if (node.role === 'human') {
+    if (node.agentKind !== null || node.parallel || node.acceptance.requireConclusion
+        || node.acceptance.minArtifactRefs || node.acceptance.minEvidenceRefs
+        || node.decisionOptions.length < 2) {
+      context.addIssue({ code: 'custom', message: 'invalid human node' })
+    }
+  } else if (!node.agentKind || node.decisionOptions.length) {
+    context.addIssue({ code: 'custom', message: 'invalid Agent node' })
+  }
+})
+const graphContentFields = {
+  template: z.literal('task-graph'),
+  nodes: z.array(nodeSchema).min(1).max(MAX_GRAPH_NODES),
+}
+const graphInputSchema = z.strictObject(graphContentFields)
+const graphRecordSchema = z.strictObject({
+  graphId: z.string().regex(GRAPH_ID),
+  version: z.literal(TASK_GRAPH_VERSION),
+  recordType: z.literal('task-graph'),
+  ...graphContentFields,
+})
+
+const nodeStateSchema = z.strictObject({
+  nodeId: publicIdSchema,
+  status: z.enum(STATUSES),
+  attention: z.enum(ATTENTION_STATES),
+  attempts: z.number().int().min(0).max(1000),
+  entryIds: uniqueArray(publicIdSchema, 128),
+  artifactIds: uniqueArray(z.string().regex(OUTCOME_ID), 128),
+  evidenceIds: uniqueArray(z.string().regex(OUTCOME_ID), 128),
+  conclusionHash: z.union([z.literal(''), z.string().regex(SHA256)]),
+  decisionOptionId: z.union([z.literal(''), publicIdSchema]),
+  updatedAt: z.number().int().min(0),
+})
+const cursorSchema = z.strictObject({
+  version: z.literal(TASK_GRAPH_CURSOR_VERSION),
+  graph: graphRecordSchema,
+  nodeStates: z.array(nodeStateSchema).min(1).max(MAX_GRAPH_NODES),
+  currentNodeIds: uniqueArray(publicIdSchema),
+  terminalState: z.enum(TERMINAL_STATES),
+})
+
+function deriveId(prefix, body) {
+  return `${prefix}-${createHash('sha256').update(canonicalJson(body)).digest('hex')}`
+}
+
+function validateGraphRelations(graph, targetKinds = null) {
+  const nodeIds = new Set(graph.nodes.map(node => node.nodeId))
+  if (nodeIds.size !== graph.nodes.length || !graph.nodes.some(node => node.terminal)) {
+    fail('TASK_GRAPH_SCHEMA_INVALID')
+  }
+  const allowedKinds = targetKinds ? new Set(targetKinds) : null
+  for (const node of graph.nodes) {
+    if (node.dependsOn.some(nodeId => !nodeIds.has(nodeId))
+        || node.inputNodeIds.some(nodeId => !nodeIds.has(nodeId))
+        || (allowedKinds && node.agentKind && !allowedKinds.has(node.agentKind))) {
+      fail('TASK_GRAPH_SCHEMA_INVALID')
+    }
+  }
+  const visiting = new Set()
+  const visited = new Set()
+  const byId = new Map(graph.nodes.map(node => [node.nodeId, node]))
+  const visit = (nodeId) => {
+    if (visiting.has(nodeId)) fail('TASK_GRAPH_CYCLE')
+    if (visited.has(nodeId)) return
+    visiting.add(nodeId)
+    for (const dependency of byId.get(nodeId).dependsOn) visit(dependency)
+    visiting.delete(nodeId)
+    visited.add(nodeId)
+  }
+  for (const node of graph.nodes) visit(node.nodeId)
+}
+
+function createTaskGraph(input, targetKinds = null) {
+  const parsed = graphInputSchema.safeParse(input)
+  if (!parsed.success) fail('TASK_GRAPH_SCHEMA_INVALID')
+  const body = {
+    version: TASK_GRAPH_VERSION,
+    recordType: 'task-graph',
+    ...parsed.data,
+  }
+  const graph = JSON.parse(canonicalJson({ graphId: deriveId('task-graph', body), ...body }))
+  validateGraphRelations(graph, targetKinds)
+  return graph
+}
+
+function parseTaskGraph(input, targetKinds = null) {
+  const parsed = graphRecordSchema.safeParse(input)
+  if (!parsed.success) fail('TASK_GRAPH_SCHEMA_INVALID')
+  const graph = JSON.parse(canonicalJson(parsed.data))
+  const { graphId, ...body } = graph
+  if (deriveId('task-graph', body) !== graphId) fail('TASK_GRAPH_ID_MISMATCH')
+  validateGraphRelations(graph, targetKinds)
+  return graph
+}
+
+function createTaskGraphCursor(graphInput, now = Date.now()) {
+  const graph = parseTaskGraph(graphInput)
+  return parseTaskGraphCursor({
+    version: TASK_GRAPH_CURSOR_VERSION,
+    graph,
+    nodeStates: graph.nodes.map(node => ({
+      nodeId: node.nodeId,
+      status: 'pending',
+      attention: 'none',
+      attempts: 0,
+      entryIds: [],
+      artifactIds: [],
+      evidenceIds: [],
+      conclusionHash: '',
+      decisionOptionId: '',
+      updatedAt: now,
+    })),
+    currentNodeIds: [],
+    terminalState: 'running',
+  })
+}
+
+function terminalStateFor(graph, nodeStates) {
+  const states = new Map(nodeStates.map(state => [state.nodeId, state]))
+  const terminal = graph.nodes.filter(node => node.terminal)
+  if (terminal.every(node => states.get(node.nodeId)?.status === 'accepted')) return 'accepted'
+  if (terminal.some(node => states.get(node.nodeId)?.status === 'rejected')) return 'rejected'
+  if (nodeStates.some(state => state.status === 'failed')) return 'failed'
+  return 'running'
+}
+
+function parseTaskGraphCursor(input, targetKinds = null) {
+  const parsed = cursorSchema.safeParse(input)
+  if (!parsed.success) fail('TASK_GRAPH_CURSOR_INVALID')
+  const cursor = JSON.parse(canonicalJson(parsed.data))
+  const graph = parseTaskGraph(cursor.graph, targetKinds)
+  const nodeIds = graph.nodes.map(node => node.nodeId)
+  if (cursor.nodeStates.length !== nodeIds.length
+      || cursor.nodeStates.some((state, index) => state.nodeId !== nodeIds[index])
+      || cursor.currentNodeIds.some(nodeId => !nodeIds.includes(nodeId))) {
+    fail('TASK_GRAPH_CURSOR_INVALID')
+  }
+  const currentIds = new Set(cursor.currentNodeIds)
+  if (cursor.nodeStates.some(state => (
+    currentIds.has(state.nodeId)
+      ? !['running', 'waiting'].includes(state.status)
+      : ['running', 'waiting'].includes(state.status)
+  ))) fail('TASK_GRAPH_CURSOR_INVALID')
+  if (cursor.terminalState !== terminalStateFor(graph, cursor.nodeStates)) {
+    fail('TASK_GRAPH_CURSOR_INVALID')
+  }
+  return { ...cursor, graph }
+}
+
+function updateTaskGraphCursor(cursorInput, nodeId, updates, now = Date.now()) {
+  const cursor = parseTaskGraphCursor(cursorInput)
+  const index = cursor.nodeStates.findIndex(state => state.nodeId === nodeId)
+  if (index < 0) fail('TASK_GRAPH_NODE_UNKNOWN')
+  const nodeStates = cursor.nodeStates.map((state, stateIndex) => (
+    stateIndex === index ? { ...state, ...updates, nodeId, updatedAt: now } : state
+  ))
+  const currentNodeIds = nodeStates
+    .filter(state => ['running', 'waiting'].includes(state.status))
+    .map(state => state.nodeId)
+  return parseTaskGraphCursor({
+    ...cursor,
+    nodeStates,
+    currentNodeIds,
+    terminalState: terminalStateFor(cursor.graph, nodeStates),
+  })
+}
+
+function taskGraphNode(cursorInput, nodeId) {
+  const cursor = parseTaskGraphCursor(cursorInput)
+  return cursor.graph.nodes.find(node => node.nodeId === nodeId) || null
+}
+
+function readyTaskGraphNodes(cursorInput) {
+  const cursor = parseTaskGraphCursor(cursorInput)
+  const states = new Map(cursor.nodeStates.map(state => [state.nodeId, state]))
+  return cursor.graph.nodes.filter(node => (
+    states.get(node.nodeId).status === 'pending'
+    && node.dependsOn.every(nodeId => states.get(nodeId)?.status === 'accepted')
+  ))
+}
+
+function terminalTaskGraphState(cursorInput) {
+  const cursor = parseTaskGraphCursor(cursorInput)
+  return terminalStateFor(cursor.graph, cursor.nodeStates)
+}
+
+module.exports = {
+  ATTENTION_STATES,
+  ROLES,
+  STATUSES,
+  TASK_GRAPH_CURSOR_VERSION,
+  TASK_GRAPH_VERSION,
+  createTaskGraph,
+  createTaskGraphCursor,
+  parseTaskGraph,
+  parseTaskGraphCursor,
+  readyTaskGraphNodes,
+  taskGraphNode,
+  terminalTaskGraphState,
+  updateTaskGraphCursor,
+}

--- a/desktop/test/local-workspace-auto.test.cjs
+++ b/desktop/test/local-workspace-auto.test.cjs
@@ -26,6 +26,161 @@ function pendingHumanGate(workspace, timeoutMs = 2000) {
     workspace.on('changed', changed)
   })
 }
+
+function graphNode(overrides = {}) {
+  return {
+    nodeId: 'primary-codex', role: 'primary', agentKind: 'codex',
+    dependsOn: [], inputNodeIds: [], expectedOutput: 'Produce one durable conclusion.',
+    acceptance: { requireConclusion: true, minArtifactRefs: 1, minEvidenceRefs: 1 },
+    terminal: false, parallel: false, decisionOptions: [],
+    ...overrides,
+  }
+}
+
+function evidenceTaskGraph() {
+  return {
+    template: 'task-graph',
+    nodes: [
+      graphNode({ parallel: true }),
+      graphNode({ nodeId: 'primary-hermes', agentKind: 'hermes', parallel: true }),
+      graphNode({
+        nodeId: 'review-workbuddy', role: 'reviewer', agentKind: 'workbuddy',
+        dependsOn: ['primary-codex', 'primary-hermes'],
+        inputNodeIds: ['primary-codex', 'primary-hermes'],
+        expectedOutput: 'Review both Primary results independently.',
+      }),
+      graphNode({
+        nodeId: 'decide-kimi', role: 'arbiter', agentKind: 'kimi',
+        dependsOn: ['review-workbuddy'], inputNodeIds: ['review-workbuddy'],
+        expectedOutput: 'Resolve the reviewed conflict using typed Evidence.',
+        terminal: true,
+      }),
+    ],
+  }
+}
+
+test('task graph runs independent branches in parallel and completes from typed Evidence', async (t) => {
+  const { directory, calls, options } = fixture()
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }))
+  const ledger = new RunLedger({ storagePath: path.join(directory, 'run-ledger.json') })
+  options.runLedger = ledger
+  const primaryBarrier = deferred()
+  let activePrimaries = 0
+  let maxActivePrimaries = 0
+  options.runAgent = async (agent, prompt, workdir, runOptions) => {
+    calls.push({ agent, prompt, workdir, runOptions })
+    if (['codex', 'hermes'].includes(agent.kind)) {
+      activePrimaries += 1
+      maxActivePrimaries = Math.max(maxActivePrimaries, activePrimaries)
+      if (activePrimaries === 2) primaryBarrier.resolve()
+      await primaryBarrier.promise
+      activePrimaries -= 1
+    }
+    return {
+      text: agent.kind === 'codex'
+        ? 'Release is ready.'
+        : (agent.kind === 'hermes' ? 'Release is blocked.' : `${agent.kind} typed decision.`),
+      sessionRef: runOptions.sessionRef || `${agent.kind}-session`,
+    }
+  }
+  const workspace = new LocalWorkspace(options)
+  await workspace.refreshAgents()
+  const group = workspace.createGroup({
+    name: 'Evidence task graph',
+    agentKinds: ['codex', 'hermes', 'workbuddy', 'kimi'],
+    workdir: directory,
+  })
+
+  const started = await workspace.sendMessage({
+    groupId: group.id,
+    text: 'Assess release readiness with independent review.',
+    mode: 'auto',
+    maxRounds: 6,
+    targetKinds: ['codex', 'hermes', 'workbuddy', 'kimi'],
+    workflow: evidenceTaskGraph(),
+  })
+  await workspace.activeRuns.get(group.id).promise
+
+  assert.equal(maxActivePrimaries, 2)
+  assert.deepEqual(calls.map(call => call.agent.kind), [
+    'codex', 'hermes', 'workbuddy', 'kimi',
+  ])
+  assert.equal(calls.every(call => !call.prompt.includes('ROUNDRELAY_CONSENSUS')), true)
+  assert.equal(calls[2].runOptions.sessionRef, '')
+  assert.match(calls[2].prompt, /ROUNDRELAY_TASK_GRAPH_V1/)
+  assert.match(calls[2].prompt, /\[conflict\]/)
+  assert.equal(calls[3].runOptions.sessionRef, '')
+
+  const durable = ledger.list(group.id)[0]
+  assert.equal(durable.status, 'completed')
+  assert.equal(durable.orchestration.version, 3)
+  assert.equal(durable.orchestration.taskGraph.terminalState, 'accepted')
+  const states = Object.fromEntries(durable.orchestration.taskGraph.nodeStates.map(state => (
+    [state.nodeId, state]
+  )))
+  assert.equal(states['review-workbuddy'].attention, 'review')
+  assert.equal(states['decide-kimi'].attention, 'decision')
+  assert.equal(durable.orchestration.taskGraph.nodeStates.every(state => (
+    state.status === 'accepted'
+  )), true)
+  assert.equal(durable.orchestration.collaboration.entries.some(entry => (
+    entry.entryType === 'decision'
+    && entry.refs.some(reference => durable.orchestration.collaboration.entries.some(
+      candidate => candidate.entryId === reference && candidate.entryType === 'conflict',
+    ))
+  )), true)
+  assert.equal(workspace.snapshot().messages.filter(message => (
+    message.threadRootId === started.threadRootId && message.role === 'agent'
+  )).length, 4)
+})
+
+test('task graph Human node uses a typed decision instead of Agent consensus', async (t) => {
+  const { directory, calls, options } = fixture()
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }))
+  const ledger = new RunLedger({ storagePath: path.join(directory, 'run-ledger.json') })
+  options.runLedger = ledger
+  const workspace = new LocalWorkspace(options)
+  await workspace.refreshAgents()
+  const group = workspace.createGroup({
+    name: 'Human decision graph', agentKinds: ['codex', 'hermes'], workdir: directory,
+  })
+  const graph = {
+    template: 'task-graph',
+    nodes: [
+      graphNode(),
+      graphNode({
+        nodeId: 'human-release', role: 'human', agentKind: null,
+        dependsOn: ['primary-codex'], inputNodeIds: ['primary-codex'],
+        expectedOutput: 'Approve or reject the release decision.',
+        acceptance: { requireConclusion: false, minArtifactRefs: 0, minEvidenceRefs: 0 },
+        terminal: true,
+        decisionOptions: [
+          { optionId: 'approve-release', name: 'Approve release', kind: 'allow_once' },
+          { optionId: 'reject-release', name: 'Reject release', kind: 'reject_once' },
+        ],
+      }),
+    ],
+  }
+
+  await workspace.sendMessage({
+    groupId: group.id,
+    text: 'Prepare a release decision.',
+    mode: 'auto', maxRounds: 4, targetKinds: ['codex', 'hermes'], workflow: graph,
+  })
+  const gate = await pendingHumanGate(workspace)
+  assert.equal(gate.type, 'decision')
+  assert.equal(ledger.get(gate.runId).orchestration.taskGraph.nodeStates[1].status, 'waiting')
+  workspace.decideHumanGate(gate.gateId, {
+    status: 'approved', optionId: 'approve-release', actorId: 'local-user',
+  })
+  await workspace.activeRuns.get(group.id).promise
+
+  const durable = ledger.get(gate.runId)
+  assert.equal(durable.status, 'completed')
+  assert.equal(durable.continuation.state, 'completed')
+  assert.equal(durable.orchestration.taskGraph.nodeStates[1].decisionOptionId, 'approve-release')
+  assert.equal(calls.length, 1)
+})
 test('auto send preflights atomically, persists one root, and starts at round one', async (t) => {
   const { directory, calls, options } = fixture()
   t.after(() => fs.rmSync(directory, { recursive: true, force: true }))

--- a/desktop/test/local-workspace-human-gate-recovery.test.cjs
+++ b/desktop/test/local-workspace-human-gate-recovery.test.cjs
@@ -88,6 +88,148 @@ function removeContextPack(workspace, contextPackId) {
   ))
 }
 
+function decisionTaskGraph() {
+  return {
+    template: 'task-graph',
+    nodes: [{
+      nodeId: 'primary-codex', role: 'primary', agentKind: 'codex',
+      dependsOn: [], inputNodeIds: [], expectedOutput: 'Produce a durable recommendation.',
+      acceptance: { requireConclusion: true, minArtifactRefs: 1, minEvidenceRefs: 1 },
+      terminal: false, parallel: false, decisionOptions: [],
+    }, {
+      nodeId: 'human-decision', role: 'human', agentKind: null,
+      dependsOn: ['primary-codex'], inputNodeIds: ['primary-codex'],
+      expectedOutput: 'Approve or reject the recommendation.',
+      acceptance: { requireConclusion: false, minArtifactRefs: 0, minEvidenceRefs: 0 },
+      terminal: true, parallel: false,
+      decisionOptions: [
+        { optionId: 'approve-graph', name: 'Approve recommendation', kind: 'allow_once' },
+        { optionId: 'reject-graph', name: 'Reject recommendation', kind: 'reject_once' },
+      ],
+    }],
+  }
+}
+
+test('task-graph Human decisions resume from the durable v3 cursor after restart', async (t) => {
+  const { directory, calls, options } = fixture()
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }))
+  const ledgerPath = path.join(directory, 'run-ledger.json')
+  options.runLedger = new RunLedger({ storagePath: ledgerPath })
+  const workspace = new LocalWorkspace(options)
+  await workspace.refreshAgents()
+  const group = workspace.createGroup({
+    name: 'Restart task graph', agentKinds: ['codex', 'hermes'], workdir: directory,
+  })
+
+  await workspace.sendMessage({
+    groupId: group.id,
+    text: 'Prepare a durable recommendation for approval.',
+    mode: 'auto', maxRounds: 4, targetKinds: ['codex', 'hermes'],
+    workflow: decisionTaskGraph(),
+  })
+  const pending = await pendingGate(workspace)
+  await workspace.stopAll()
+
+  const waiting = new RunLedger({ storagePath: ledgerPath }).get(pending.runId)
+  assert.equal(waiting.status, 'waiting')
+  assert.equal(waiting.orchestration.version, 3)
+  assert.deepEqual(waiting.orchestration.taskGraph.nodeStates.map(state => state.status), [
+    'accepted', 'waiting',
+  ])
+
+  const restartedLedger = new RunLedger({ storagePath: ledgerPath })
+  const restarted = new LocalWorkspace({ ...options, runLedger: restartedLedger })
+  await restarted.refreshAgents()
+  restarted.decideHumanGate(pending.gateId, {
+    status: 'approved', optionId: 'approve-graph', actorId: 'local-user',
+  })
+  const terminal = await waitForTerminalRun(restartedLedger, pending.runId)
+
+  assert.equal(terminal.status, 'completed')
+  assert.equal(terminal.continuation.state, 'completed')
+  assert.equal(terminal.orchestration.taskGraph.terminalState, 'accepted')
+  assert.equal(
+    terminal.orchestration.taskGraph.nodeStates[1].decisionOptionId,
+    'approve-graph',
+  )
+  assert.equal(calls.length, 1)
+
+  const secondRestart = new LocalWorkspace({
+    ...options,
+    runLedger: new RunLedger({ storagePath: ledgerPath }),
+  })
+  await secondRestart.refreshAgents()
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(calls.length, 1)
+})
+
+test('task-graph Agent slots resume into typed acceptance after a permission Gate restart', async (t) => {
+  const { directory, calls, options } = fixture()
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }))
+  const ledgerPath = path.join(directory, 'run-ledger.json')
+  options.runLedger = new RunLedger({ storagePath: ledgerPath })
+  let appliedDecisions = 0
+  options.runAgent = async (agent, _prompt, _workdir, runOptions) => {
+    calls.push({ agent, runOptions })
+    await runOptions.onSessionRef('kimi-task-graph-session', { transport: 'acp' })
+    const decision = await runOptions.onPermissionRequest({
+      options: [
+        { optionId: 'allow-once', name: 'Allow once', kind: 'allow_once' },
+        { optionId: 'reject-once', name: 'Reject once', kind: 'reject_once' },
+      ],
+      operation: { kind: 'write', path: 'typed-result.txt' },
+    }, { signal: runOptions.signal })
+    appliedDecisions += 1
+    return {
+      text: `Typed result after ${decision.optionId}`,
+      sessionRef: 'kimi-task-graph-session',
+    }
+  }
+  const workspace = new LocalWorkspace(options)
+  await workspace.refreshAgents()
+  const group = workspace.createGroup({
+    name: 'Restart task graph Agent',
+    agentKinds: ['kimi', 'codex'],
+    workdir: directory,
+    allowWrite: true,
+  })
+  await workspace.sendMessage({
+    groupId: group.id,
+    text: 'Produce the typed result after permission.',
+    mode: 'auto', maxRounds: 2, targetKinds: ['kimi', 'codex'],
+    workflow: {
+      template: 'task-graph',
+      nodes: [{
+        nodeId: 'primary-kimi', role: 'primary', agentKind: 'kimi',
+        dependsOn: [], inputNodeIds: [], expectedOutput: 'Produce a durable typed result.',
+        acceptance: { requireConclusion: true, minArtifactRefs: 1, minEvidenceRefs: 1 },
+        terminal: true, parallel: false, decisionOptions: [],
+      }],
+    },
+  })
+  const pending = await pendingGate(workspace)
+  await workspace.stopAll()
+
+  const waiting = new RunLedger({ storagePath: ledgerPath }).get(pending.runId)
+  assert.deepEqual(waiting.orchestration.taskGraph.currentNodeIds, ['primary-kimi'])
+  assert.equal(waiting.orchestration.taskGraph.nodeStates[0].status, 'running')
+
+  const restartedLedger = new RunLedger({ storagePath: ledgerPath })
+  const restarted = new LocalWorkspace({ ...options, runLedger: restartedLedger })
+  await restarted.refreshAgents()
+  restarted.decideHumanGate(pending.gateId, {
+    status: 'approved', optionId: 'allow-once', actorId: 'local-user',
+  })
+  const terminal = await waitForTerminalRun(restartedLedger, pending.runId)
+
+  assert.equal(terminal.status, 'completed')
+  assert.equal(terminal.orchestration.taskGraph.nodeStates[0].status, 'accepted')
+  assert.equal(terminal.orchestration.taskGraph.nodeStates[0].artifactIds.length, 1)
+  assert.equal(terminal.orchestration.taskGraph.nodeStates[0].evidenceIds.length, 1)
+  assert.equal(calls.length, 2)
+  assert.equal(appliedDecisions, 1)
+})
+
 async function verifyAutomaticGateRecovery(t, gateIndex) {
   const { directory, options } = fixture()
   t.after(() => fs.rmSync(directory, { recursive: true, force: true }))

--- a/desktop/test/run-ledger.test.cjs
+++ b/desktop/test/run-ledger.test.cjs
@@ -9,6 +9,7 @@ const {
   appendHandoff,
   emptyCollaborationState,
 } = require('../src/collaboration-records.cjs')
+const { createTaskGraph, createTaskGraphCursor } = require('../src/task-graph-records.cjs')
 
 test('keeps the ledger facade limited to RunLedger', () => {
   assert.deepEqual(Object.keys(require('../src/run-ledger.cjs')), ['RunLedger'])
@@ -147,6 +148,55 @@ test('loads exact v1 orchestration cursors and persists strict v2 collaboration 
     currentRound: 1,
     maxRounds: 2,
     orchestration: { version: 1, ...baseCursor, collaboration },
+  }), { message: 'RUN_LEDGER_RECORD_INVALID' })
+})
+
+test('persists strict v3 task-graph cursors without weakening v1 and v2 loading', (t) => {
+  const { storagePath } = fixture(t)
+  const ledger = new RunLedger({ storagePath, now: () => 1000 })
+  const graph = createTaskGraph({
+    template: 'task-graph',
+    nodes: [{
+      nodeId: 'primary-codex', role: 'primary', agentKind: 'codex',
+      dependsOn: [], inputNodeIds: [], expectedOutput: 'Produce a durable conclusion.',
+      acceptance: { requireConclusion: true, minArtifactRefs: 1, minEvidenceRefs: 1 },
+      terminal: true, parallel: false, decisionOptions: [],
+    }],
+  }, ['codex'])
+  const taskGraph = createTaskGraphCursor(graph, 1000)
+  const saved = ledger.checkpoint({
+    ...runRecord('run-orchestration-v3', 'group-orchestration-v3'),
+    mode: 'auto',
+    currentRound: 0,
+    maxRounds: 2,
+    orchestration: {
+      version: 3,
+      workflow: 'auto',
+      template: 'task-graph',
+      currentKind: '',
+      pendingKinds: ['codex'],
+      activeKinds: ['codex'],
+      successfulKinds: [],
+      agreementKinds: [],
+      attachmentRecipients: [],
+      totalSuccesses: 0,
+      terminalFailureOccurred: false,
+      collaboration: emptyCollaborationState(),
+      taskGraph,
+    },
+  })
+  assert.equal(saved.orchestration.version, 3)
+  assert.deepEqual(saved.orchestration.taskGraph, taskGraph)
+  assert.deepEqual(
+    new RunLedger({ storagePath, now: () => 1100 }).get(saved.runId).orchestration,
+    saved.orchestration,
+  )
+  assert.throws(() => ledger.checkpoint({
+    runId: saved.runId,
+    orchestration: {
+      ...saved.orchestration,
+      taskGraph: { ...taskGraph, terminalState: 'accepted' },
+    },
   }), { message: 'RUN_LEDGER_RECORD_INVALID' })
 })
 

--- a/desktop/test/task-graph-records.test.cjs
+++ b/desktop/test/task-graph-records.test.cjs
@@ -1,0 +1,110 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  createTaskGraph,
+  createTaskGraphCursor,
+  parseTaskGraph,
+  parseTaskGraphCursor,
+  readyTaskGraphNodes,
+  terminalTaskGraphState,
+  updateTaskGraphCursor,
+} = require('../src/task-graph-records.cjs')
+
+function node(overrides = {}) {
+  return {
+    nodeId: 'primary-codex',
+    role: 'primary',
+    agentKind: 'codex',
+    dependsOn: [],
+    inputNodeIds: [],
+    expectedOutput: 'Produce one evidence-backed conclusion.',
+    acceptance: {
+      requireConclusion: true,
+      minArtifactRefs: 1,
+      minEvidenceRefs: 1,
+    },
+    terminal: false,
+    parallel: true,
+    decisionOptions: [],
+    ...overrides,
+  }
+}
+
+function workflow() {
+  return {
+    template: 'task-graph',
+    nodes: [
+      node(),
+      node({
+        nodeId: 'review-hermes',
+        role: 'reviewer',
+        agentKind: 'hermes',
+        dependsOn: ['primary-codex'],
+        inputNodeIds: ['primary-codex'],
+        expectedOutput: 'Review the Primary result independently.',
+        terminal: true,
+        parallel: false,
+      }),
+    ],
+  }
+}
+
+test('creates content-addressed acyclic task graphs and durable cursors', () => {
+  const graph = createTaskGraph(workflow(), ['codex', 'hermes'])
+  assert.match(graph.graphId, /^task-graph-[a-f0-9]{64}$/)
+  assert.deepEqual(parseTaskGraph(graph, ['codex', 'hermes']), graph)
+
+  let cursor = createTaskGraphCursor(graph, 1000)
+  assert.deepEqual(readyTaskGraphNodes(cursor).map(candidate => candidate.nodeId), [
+    'primary-codex',
+  ])
+  cursor = updateTaskGraphCursor(cursor, 'primary-codex', {
+    status: 'running', attempts: 1,
+  }, 1100)
+  assert.deepEqual(cursor.currentNodeIds, ['primary-codex'])
+  cursor = updateTaskGraphCursor(cursor, 'primary-codex', {
+    status: 'accepted',
+    entryIds: [`blackboard-entry-${'a'.repeat(64)}`],
+    artifactIds: [`artifact-${'b'.repeat(64)}`],
+    evidenceIds: [`evidence-${'c'.repeat(64)}`],
+    conclusionHash: 'd'.repeat(64),
+  }, 1200)
+  assert.deepEqual(readyTaskGraphNodes(cursor).map(candidate => candidate.nodeId), [
+    'review-hermes',
+  ])
+  cursor = updateTaskGraphCursor(cursor, 'review-hermes', {
+    status: 'accepted', attempts: 1,
+  }, 1300)
+  assert.equal(terminalTaskGraphState(cursor), 'accepted')
+  assert.deepEqual(parseTaskGraphCursor({ ...cursor, terminalState: 'accepted' }), {
+    ...cursor,
+    terminalState: 'accepted',
+  })
+})
+
+test('rejects cycles, unknown Agents, malformed Human decisions, and tampering', () => {
+  assert.throws(() => createTaskGraph({
+    template: 'task-graph',
+    nodes: [
+      node({ nodeId: 'a', dependsOn: ['b'], inputNodeIds: ['b'], terminal: true }),
+      node({ nodeId: 'b', agentKind: 'hermes', dependsOn: ['a'], inputNodeIds: ['a'] }),
+    ],
+  }, ['codex', 'hermes']), { message: 'TASK_GRAPH_CYCLE' })
+  assert.throws(() => createTaskGraph(workflow(), ['codex']), {
+    message: 'TASK_GRAPH_SCHEMA_INVALID',
+  })
+  assert.throws(() => createTaskGraph({
+    template: 'task-graph',
+    nodes: [node({
+      nodeId: 'human', role: 'human', agentKind: null, terminal: true, parallel: false,
+      acceptance: { requireConclusion: false, minArtifactRefs: 0, minEvidenceRefs: 0 },
+      decisionOptions: [{ optionId: 'accept', name: 'Accept', kind: 'allow_once' }],
+    })],
+  }), { message: 'TASK_GRAPH_SCHEMA_INVALID' })
+
+  const graph = createTaskGraph(workflow())
+  assert.throws(() => parseTaskGraph({ ...graph, graphId: `task-graph-${'0'.repeat(64)}` }), {
+    message: 'TASK_GRAPH_ID_MISMATCH',
+  })
+})


### PR DESCRIPTION
## Summary

- add strict content-addressed task graph definitions with explicit nodes, dependencies, input edges, roles, typed acceptance requirements, and terminal nodes
- persist a v3 restart-safe orchestration cursor while retaining exact v1/v2 loading
- execute explicitly parallel read-only branches concurrently through the existing scheduler and Harness
- isolate Reviewer and Arbiter invocations from Primary native Sessions
- evaluate node completion from durable conclusion, Artifact, Evidence, and Human decision records instead of `ROUNDRELAY_CONSENSUS`
- route conflicting Primary claims through persistent review/decision attention and typed Arbiter or Human decisions
- keep existing bounded automatic round-robin as the default compatibility template; task graphs are opt-in through the same `local-workspace:send` contract

## Stability boundaries

- no server, cloud storage, renderer shell access, credential exposure, or new write permission path
- parallel execution is limited to nodes explicitly marked parallel in read-only groups; write-capable graphs remain serial
- isolated Reviewer/Arbiter nodes receive only the immutable task and selected typed collaboration package
- malformed, cyclic, tampered, cross-Agent, or unsupported workflow records fail closed before Agent launch
- Human and Agent Gate continuations retain the exact running node across shutdown and resume once from the durable cursor
- legacy Role Review input remains unsupported and legacy round-robin behavior is unchanged

## Acceptance evidence

- Primary, Reviewer, Arbiter, and Human node contracts are covered
- two independent Primary branches are held at a barrier and proven concurrent
- Reviewer and Arbiter calls use empty native Session refs
- conflicting claims persist a conflict record; review and decision attention remain visible in the final cursor
- Arbiter/Human decision records reference the conflicts they resolve
- terminal completion requires typed Artifact/Evidence or Human decision acceptance
- v3 cursors round-trip through journal recovery and restart
- Human decision and Agent permission Gate restart tests prove no completed node is rerun

## Verification

- `npm --prefix desktop test` (`954/954`)
- `npm --prefix frontend test` (`253/253`)
- `npm --prefix frontend run build`
- `npm --prefix frontend run build:desktop`
- `npm --prefix desktop run pack`
- `npm --prefix desktop run eval:deterministic` (6 cases, 18 results, reproducible matrix)
- packaged Electron `39.8.10` launched from `desktop/dist/mac-arm64/Meldwork.app` with an isolated profile
- CDP runtime: `readyState=complete`, `1440x920`, body text length `1143`, nonblank usable main window after onboarding dismissal

`electron-builder` could not find a valid Developer ID identity on this machine, so the local `pack` remains unsigned as expected.

Closes #23

Stacked on #41.
